### PR TITLE
feat: 32 admin tools (Models, Hub, Access Groups, Credentials, Keys) — US #535

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,10 +13,16 @@ MCP server for the LiteLLM proxy. Python 3.12, fastmcp (`mcp.server.fastmcp`), h
 
 ## Conventions
 
-- All tools accept a `verbosity: str` argument (`minimal` / `standard` / `full`) and route through `_filter_response`.
-- Add new resource shapes to `RESPONSE_FIELDS` in `src/server.py`.
+- All read-shaped tools accept a `verbosity: str` argument (`minimal` / `standard` / `full`) and route through `_filter_response`. Write/admin tools generally don't filter (`update_model`, `add_model`, etc. return upstream as-is).
+- Add new resource shapes to `RESPONSE_FIELDS` in `src/server.py`. Current shapes: `model`, `access_group`, `credential`, `key`, `public_hub`. The `credential.standard` shape intentionally drops `credential_values` to avoid leaking secrets — use `full` to inspect.
 - New endpoints go on `LiteLLMClient` first, then a thin `@mcp.tool()` wrapper in `server.py`.
+- For body schemas with many optional fields (`GenerateKeyRequest`, `UpdateKeyRequest`, `RegenerateKeyRequest`), expose ~12 common fields as named args and accept the long tail through an `extras: Optional[dict]` argument (merged into the body via `_build_key_body`).
 - Keep transport agnostic: never call `print` / write to stdout in stdio mode.
+
+## Current scope (US #534 + #535)
+
+- **#534 (v1.0.0):** foundation, `list_models`.
+- **#535:** 32 admin tools — Models (5), Model Hub (5), Access Groups (5), Credentials (6), Keys (11). All wrapped with unit tests against `AsyncMock(LiteLLMClient)`.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ MCP server for [LiteLLM](https://github.com/BerriAI/litellm) proxy administratio
 
 **Upstream API reference:** [LiteLLM proxy Swagger](https://litellm-api.up.railway.app/).
 
-Foundation slice (US #534): exposes a single tool — `list_models` — against a running LiteLLM proxy.
-Subsequent slices add models/credentials/keys/users/spend/teams/guardrails/routing/passthrough/MCP-gateway tools.
+Foundation (US #534) shipped `list_models`. Admin slice (US #535) adds 32 tools
+covering models, model hub, model access groups, credentials, and virtual keys.
+Subsequent slices add identity/teams/spend/execution (#536), governance and
+passthrough (#538), and the MCP-of-MCPs gateway (#558).
 
 ## Setup
 
@@ -68,9 +70,69 @@ Add to your Claude Code MCP settings (project-scoped `.mcp.json` recommended):
 
 ## Tools
 
-| Tool | Description |
-|------|-------------|
-| `list_models` | List models exposed by the proxy (`GET /v1/models`). Verbosity: `minimal` / `standard` / `full`. |
+All tools accept a `verbosity` arg (`minimal` / `standard` / `full`) where it makes sense; see `RESPONSE_FIELDS` in `src/server.py` for the shapes. The `credential` shape deliberately omits `credential_values` at `standard` to avoid leaking secrets into agent transcripts — use `full` to inspect.
+
+### Models (6)
+
+| Tool | Endpoint |
+|------|----------|
+| `list_models` | `GET /v1/models` |
+| `get_model` | `GET /v1/models/{model_id}` |
+| `get_model_info` | `GET /model/info` (admin, full deployment details) |
+| `add_model` | `POST /model/new` |
+| `update_model` | `PATCH /model/{model_id}/update` |
+| `delete_model` | `POST /model/delete` |
+
+### Model Hub (5)
+
+| Tool | Endpoint |
+|------|----------|
+| `list_public_models` | `GET /public/model_hub` |
+| `get_public_hub_info` | `GET /public/model_hub/info` |
+| `get_model_cost_map` | `GET /public/litellm_model_cost_map` |
+| `make_model_group_public` | `POST /model_group/make_public` |
+| `update_model_hub_links` | `POST /model_hub/update_useful_links` |
+
+### Model Access Groups (5)
+
+| Tool | Endpoint |
+|------|----------|
+| `list_model_access_groups` | `GET /access_group/list` |
+| `get_model_access_group` | `GET /access_group/{access_group}/info` |
+| `create_model_access_group` | `POST /access_group/new` |
+| `update_model_access_group` | `PUT /access_group/{access_group}/update` |
+| `delete_model_access_group` | `DELETE /access_group/{access_group}/delete` |
+
+### Credentials (6)
+
+| Tool | Endpoint |
+|------|----------|
+| `list_credentials` | `GET /credentials` |
+| `get_credential` | `GET /credentials/by_name/{credential_name}` |
+| `get_credential_by_model` | `GET /credentials/by_model/{model_id}` |
+| `create_credential` | `POST /credentials` |
+| `update_credential` | `PATCH /credentials/{credential_name}` |
+| `delete_credential` | `DELETE /credentials/{credential_name}` |
+
+### Keys (11)
+
+| Tool | Endpoint |
+|------|----------|
+| `list_keys` | `GET /key/list` |
+| `list_key_aliases` | `GET /key/aliases` |
+| `get_key_info` | `GET /key/info` |
+| `generate_key` | `POST /key/generate` |
+| `generate_service_account_key` | `POST /key/service-account/generate` |
+| `update_key` | `POST /key/update` |
+| `regenerate_key` | `POST /key/{key}/regenerate` |
+| `set_key_blocked(blocked: bool)` | `POST /key/block` ∣ `POST /key/unblock` |
+| `delete_keys` | `POST /key/delete` |
+| `reset_key_spend` | `POST /key/{key}/reset_spend` |
+| `key_health` | `POST /key/health` |
+
+`generate_key`, `generate_service_account_key`, `update_key`, and `regenerate_key`
+expose the most common ~12 fields as named args; pass any other upstream field
+via the `extras: dict` argument (merged into the request body).
 
 ## Development
 

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -450,3 +450,43 @@ class LiteLLMClient:
             extras,
         )
         return await self._request("POST", "/key/generate", json=body)
+
+    async def generate_service_account_key(
+        self,
+        key_alias: Optional[str] = None,
+        duration: Optional[str] = None,
+        models: Optional[list[str]] = None,
+        max_budget: Optional[float] = None,
+        budget_duration: Optional[str] = None,
+        user_id: Optional[str] = None,
+        team_id: Optional[str] = None,
+        tpm_limit: Optional[int] = None,
+        rpm_limit: Optional[int] = None,
+        metadata: Optional[dict] = None,
+        guardrails: Optional[list[str]] = None,
+        blocked: Optional[bool] = None,
+        extras: Optional[dict] = None,
+    ) -> dict:
+        """Generate a service-account virtual key (`POST /key/service-account/generate`).
+
+        Same body shape as `generate_key`, but the upstream tags the key as a
+        service account (no human user binding required).
+        """
+        body = self._build_key_body(
+            {
+                "key_alias": key_alias,
+                "duration": duration,
+                "models": models,
+                "max_budget": max_budget,
+                "budget_duration": budget_duration,
+                "user_id": user_id,
+                "team_id": team_id,
+                "tpm_limit": tpm_limit,
+                "rpm_limit": rpm_limit,
+                "metadata": metadata,
+                "guardrails": guardrails,
+                "blocked": blocked,
+            },
+            extras,
+        )
+        return await self._request("POST", "/key/service-account/generate", json=body)

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -391,3 +391,11 @@ class LiteLLMClient:
             if v is not None
         }
         return await self._request("GET", "/key/aliases", params=params or None)
+
+    async def get_key_info(self, key: Optional[str] = None) -> dict:
+        """Get info about a key (`GET /key/info`).
+
+        If `key` is omitted, returns info about the caller's own key.
+        """
+        params = {"key": key} if key else None
+        return await self._request("GET", "/key/info", params=params)

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -399,3 +399,54 @@ class LiteLLMClient:
         """
         params = {"key": key} if key else None
         return await self._request("GET", "/key/info", params=params)
+
+    @staticmethod
+    def _build_key_body(
+        common: dict[str, Any],
+        extras: Optional[dict],
+    ) -> dict[str, Any]:
+        """Build a key request body: drop None entries from common, merge extras."""
+        body = {k: v for k, v in common.items() if v is not None}
+        if extras:
+            body.update(extras)
+        return body
+
+    async def generate_key(
+        self,
+        key_alias: Optional[str] = None,
+        duration: Optional[str] = None,
+        models: Optional[list[str]] = None,
+        max_budget: Optional[float] = None,
+        budget_duration: Optional[str] = None,
+        user_id: Optional[str] = None,
+        team_id: Optional[str] = None,
+        tpm_limit: Optional[int] = None,
+        rpm_limit: Optional[int] = None,
+        metadata: Optional[dict] = None,
+        guardrails: Optional[list[str]] = None,
+        blocked: Optional[bool] = None,
+        extras: Optional[dict] = None,
+    ) -> dict:
+        """Generate a new virtual key (`POST /key/generate`).
+
+        All fields are optional. Use `extras` for the ~30 less common fields not
+        surfaced as explicit args (see GenerateKeyRequest in upstream Swagger).
+        """
+        body = self._build_key_body(
+            {
+                "key_alias": key_alias,
+                "duration": duration,
+                "models": models,
+                "max_budget": max_budget,
+                "budget_duration": budget_duration,
+                "user_id": user_id,
+                "team_id": team_id,
+                "tpm_limit": tpm_limit,
+                "rpm_limit": rpm_limit,
+                "metadata": metadata,
+                "guardrails": guardrails,
+                "blocked": blocked,
+            },
+            extras,
+        )
+        return await self._request("POST", "/key/generate", json=body)

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -232,3 +232,21 @@ class LiteLLMClient:
     async def get_model_access_group(self, access_group: str) -> dict:
         """Get a single model access group by name (`GET /access_group/{access_group}/info`)."""
         return await self._request("GET", f"/access_group/{access_group}/info")
+
+    async def create_model_access_group(
+        self,
+        access_group: str,
+        model_names: Optional[list[str]] = None,
+        model_ids: Optional[list[str]] = None,
+    ) -> dict:
+        """Create a new model access group (`POST /access_group/new`).
+
+        Membership can be specified by `model_names` (model_name aliases) and/or
+        `model_ids` (deployment ids). Both default to None.
+        """
+        body: dict[str, Any] = {"access_group": access_group}
+        if model_names is not None:
+            body["model_names"] = model_names
+        if model_ids is not None:
+            body["model_ids"] = model_ids
+        return await self._request("POST", "/access_group/new", json=body)

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -527,3 +527,24 @@ class LiteLLMClient:
             extras,
         )
         return await self._request("POST", "/key/update", json=body)
+
+    async def regenerate_key(
+        self,
+        key: str,
+        new_master_key: Optional[str] = None,
+        duration: Optional[str] = None,
+        extras: Optional[dict] = None,
+    ) -> dict:
+        """Regenerate a virtual key (`POST /key/{key}/regenerate`).
+
+        Returns a payload containing the new key value. The body is optional;
+        if you want to atomically update settings on the new key, pass them via
+        `extras` (matches RegenerateKeyRequest in upstream Swagger).
+        """
+        body = self._build_key_body(
+            {"new_master_key": new_master_key, "duration": duration},
+            extras,
+        )
+        return await self._request(
+            "POST", f"/key/{key}/regenerate", json=body or None
+        )

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -268,3 +268,7 @@ class LiteLLMClient:
         if model_ids is not None:
             body["model_ids"] = model_ids
         return await self._request("PUT", f"/access_group/{access_group}/update", json=body)
+
+    async def delete_model_access_group(self, access_group: str) -> dict:
+        """Delete a model access group by name (`DELETE /access_group/{access_group}/delete`)."""
+        return await self._request("DELETE", f"/access_group/{access_group}/delete")

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -134,3 +134,12 @@ class LiteLLMClient:
         Calls `GET /v1/models/{model_id}`.
         """
         return await self._request("GET", f"/v1/models/{model_id}")
+
+    async def get_model_info(self, litellm_model_id: Optional[str] = None) -> dict:
+        """Get admin-side model info (all deployments, or one by litellm internal id).
+
+        Calls `GET /model/info` with optional `litellm_model_id` query param.
+        Returns the upstream payload as-is (typically `{"data": [...]}`).
+        """
+        params = {"litellm_model_id": litellm_model_id} if litellm_model_id else None
+        return await self._request("GET", "/model/info", params=params)

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -490,3 +490,40 @@ class LiteLLMClient:
             extras,
         )
         return await self._request("POST", "/key/service-account/generate", json=body)
+
+    async def update_key(
+        self,
+        key: str,
+        key_alias: Optional[str] = None,
+        duration: Optional[str] = None,
+        models: Optional[list[str]] = None,
+        max_budget: Optional[float] = None,
+        budget_duration: Optional[str] = None,
+        tpm_limit: Optional[int] = None,
+        rpm_limit: Optional[int] = None,
+        metadata: Optional[dict] = None,
+        guardrails: Optional[list[str]] = None,
+        blocked: Optional[bool] = None,
+        extras: Optional[dict] = None,
+    ) -> dict:
+        """Update a virtual key (`POST /key/update`).
+
+        Only `key` is required. All other fields are merged sparsely.
+        """
+        body = self._build_key_body(
+            {
+                "key": key,
+                "key_alias": key_alias,
+                "duration": duration,
+                "models": models,
+                "max_budget": max_budget,
+                "budget_duration": budget_duration,
+                "tpm_limit": tpm_limit,
+                "rpm_limit": rpm_limit,
+                "metadata": metadata,
+                "guardrails": guardrails,
+                "blocked": blocked,
+            },
+            extras,
+        )
+        return await self._request("POST", "/key/update", json=body)

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -312,3 +312,23 @@ class LiteLLMClient:
         if model_id is not None:
             body["model_id"] = model_id
         return await self._request("POST", "/credentials", json=body)
+
+    async def update_credential(
+        self,
+        credential_name: str,
+        credential_info: dict,
+        credential_values: dict,
+    ) -> dict:
+        """Update a credential (`PATCH /credentials/{credential_name}`).
+
+        The CredentialItem schema requires all three fields. Path id and body
+        `credential_name` should match.
+        """
+        body = {
+            "credential_name": credential_name,
+            "credential_info": credential_info,
+            "credential_values": credential_values,
+        }
+        return await self._request(
+            "PATCH", f"/credentials/{credential_name}", json=body
+        )

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -286,3 +286,7 @@ class LiteLLMClient:
     async def get_credential(self, credential_name: str) -> dict:
         """Get a credential by name (`GET /credentials/by_name/{credential_name}`)."""
         return await self._request("GET", f"/credentials/by_name/{credential_name}")
+
+    async def get_credential_by_model(self, model_id: str) -> dict:
+        """Get the credential bound to a deployment (`GET /credentials/by_model/{model_id}`)."""
+        return await self._request("GET", f"/credentials/by_model/{model_id}")

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -143,3 +143,23 @@ class LiteLLMClient:
         """
         params = {"litellm_model_id": litellm_model_id} if litellm_model_id else None
         return await self._request("GET", "/model/info", params=params)
+
+    async def add_model(
+        self,
+        model_name: str,
+        litellm_params: dict,
+        model_info: dict,
+    ) -> dict:
+        """Register a new model deployment (`POST /model/new`).
+
+        The Deployment schema requires three fields:
+        - `model_name`: alias clients call (e.g. `gpt-4o`).
+        - `litellm_params`: provider routing (`{"model": "openai/gpt-4o", "api_key": ...}`).
+        - `model_info`: deployment metadata (`{"id": "...", "db_model": false, ...}`).
+        """
+        body = {
+            "model_name": model_name,
+            "litellm_params": litellm_params,
+            "model_info": model_info,
+        }
+        return await self._request("POST", "/model/new", json=body)

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -272,3 +272,13 @@ class LiteLLMClient:
     async def delete_model_access_group(self, access_group: str) -> dict:
         """Delete a model access group by name (`DELETE /access_group/{access_group}/delete`)."""
         return await self._request("DELETE", f"/access_group/{access_group}/delete")
+
+    # ── Credential operations ──
+
+    async def list_credentials(self) -> Any:
+        """List provider credentials (`GET /credentials`).
+
+        Returns the upstream payload. Credential values themselves are not
+        included — use `get_credential` for details.
+        """
+        return await self._request("GET", "/credentials")

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -373,3 +373,21 @@ class LiteLLMClient:
             if v is not None
         }
         return await self._request("GET", "/key/list", params=params or None)
+
+    async def list_key_aliases(
+        self,
+        page: Optional[int] = None,
+        size: Optional[int] = None,
+        search: Optional[str] = None,
+        team_id: Optional[str] = None,
+    ) -> dict:
+        """List key aliases (`GET /key/aliases`).
+
+        Lighter-weight listing than `list_keys`; returns only alias metadata.
+        """
+        params = {
+            k: v
+            for k, v in {"page": page, "size": size, "search": search, "team_id": team_id}.items()
+            if v is not None
+        }
+        return await self._request("GET", "/key/aliases", params=params or None)

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -190,3 +190,9 @@ class LiteLLMClient:
         Note: the deployment id goes in the body as `{"id": ...}`, not the path.
         """
         return await self._request("POST", "/model/delete", json={"id": model_id})
+
+    # ── Model Hub operations ──
+
+    async def list_public_models(self) -> Any:
+        """List models published to the public Model Hub (`GET /public/model_hub`)."""
+        return await self._request("GET", "/public/model_hub")

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -573,3 +573,13 @@ class LiteLLMClient:
         if key_aliases is not None:
             body["key_aliases"] = key_aliases
         return await self._request("POST", "/key/delete", json=body)
+
+    async def reset_key_spend(self, key: str, reset_to: float = 0.0) -> dict:
+        """Reset a key's accumulated spend (`POST /key/{key}/reset_spend`).
+
+        `reset_to` defaults to 0.0 (typical use); pass a positive value to set
+        a starting balance.
+        """
+        return await self._request(
+            "POST", f"/key/{key}/reset_spend", json={"reset_to": reset_to}
+        )

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -290,3 +290,25 @@ class LiteLLMClient:
     async def get_credential_by_model(self, model_id: str) -> dict:
         """Get the credential bound to a deployment (`GET /credentials/by_model/{model_id}`)."""
         return await self._request("GET", f"/credentials/by_model/{model_id}")
+
+    async def create_credential(
+        self,
+        credential_name: str,
+        credential_info: dict,
+        credential_values: Optional[dict] = None,
+        model_id: Optional[str] = None,
+    ) -> dict:
+        """Create a credential (`POST /credentials`).
+
+        Either provide raw `credential_values` (e.g. `{"api_key": "sk-..."}`) or
+        bind to an existing deployment via `model_id`.
+        """
+        body: dict[str, Any] = {
+            "credential_name": credential_name,
+            "credential_info": credential_info,
+        }
+        if credential_values is not None:
+            body["credential_values"] = credential_values
+        if model_id is not None:
+            body["model_id"] = model_id
+        return await self._request("POST", "/credentials", json=body)

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -228,3 +228,7 @@ class LiteLLMClient:
     async def list_model_access_groups(self) -> Any:
         """List all model access groups (`GET /access_group/list`)."""
         return await self._request("GET", "/access_group/list")
+
+    async def get_model_access_group(self, access_group: str) -> dict:
+        """Get a single model access group by name (`GET /access_group/{access_group}/info`)."""
+        return await self._request("GET", f"/access_group/{access_group}/info")

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -250,3 +250,21 @@ class LiteLLMClient:
         if model_ids is not None:
             body["model_ids"] = model_ids
         return await self._request("POST", "/access_group/new", json=body)
+
+    async def update_model_access_group(
+        self,
+        access_group: str,
+        model_names: Optional[list[str]] = None,
+        model_ids: Optional[list[str]] = None,
+    ) -> dict:
+        """Update membership of a model access group (`PUT /access_group/{access_group}/update`).
+
+        Both fields are optional; only those passed will be sent. The upstream
+        endpoint replaces (not appends) membership.
+        """
+        body: dict[str, Any] = {}
+        if model_names is not None:
+            body["model_names"] = model_names
+        if model_ids is not None:
+            body["model_ids"] = model_ids
+        return await self._request("PUT", f"/access_group/{access_group}/update", json=body)

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -548,3 +548,11 @@ class LiteLLMClient:
         return await self._request(
             "POST", f"/key/{key}/regenerate", json=body or None
         )
+
+    async def set_key_blocked(self, key: str, blocked: bool) -> dict:
+        """Block or unblock a virtual key.
+
+        Routes to `POST /key/block` when `blocked=True`, otherwise `POST /key/unblock`.
+        """
+        path = "/key/block" if blocked else "/key/unblock"
+        return await self._request("POST", path, json={"key": key})

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -556,3 +556,20 @@ class LiteLLMClient:
         """
         path = "/key/block" if blocked else "/key/unblock"
         return await self._request("POST", path, json={"key": key})
+
+    async def delete_keys(
+        self,
+        keys: Optional[list[str]] = None,
+        key_aliases: Optional[list[str]] = None,
+    ) -> dict:
+        """Batch-delete virtual keys (`POST /key/delete`).
+
+        Provide either `keys` (raw key values) or `key_aliases` (alias names);
+        at least one must be non-empty.
+        """
+        body: dict[str, Any] = {}
+        if keys is not None:
+            body["keys"] = keys
+        if key_aliases is not None:
+            body["key_aliases"] = key_aliases
+        return await self._request("POST", "/key/delete", json=body)

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -213,3 +213,12 @@ class LiteLLMClient:
         return await self._request(
             "POST", "/model_group/make_public", json={"model_groups": model_groups}
         )
+
+    async def update_model_hub_links(self, useful_links: dict) -> dict:
+        """Update the Model Hub useful-links section (`POST /model_hub/update_useful_links`).
+
+        `useful_links` is a free-form mapping (e.g. `{"Documentation": "https://..."}`).
+        """
+        return await self._request(
+            "POST", "/model_hub/update_useful_links", json={"useful_links": useful_links}
+        )

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -222,3 +222,9 @@ class LiteLLMClient:
         return await self._request(
             "POST", "/model_hub/update_useful_links", json={"useful_links": useful_links}
         )
+
+    # ── Model Access Group operations ──
+
+    async def list_model_access_groups(self) -> Any:
+        """List all model access groups (`GET /access_group/list`)."""
+        return await self._request("GET", "/access_group/list")

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -183,3 +183,10 @@ class LiteLLMClient:
         if model_info is not None:
             body["model_info"] = model_info
         return await self._request("PATCH", f"/model/{model_id}/update", json=body)
+
+    async def delete_model(self, model_id: str) -> dict:
+        """Delete a model deployment (`POST /model/delete`).
+
+        Note: the deployment id goes in the body as `{"id": ...}`, not the path.
+        """
+        return await self._request("POST", "/model/delete", json={"id": model_id})

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -200,3 +200,7 @@ class LiteLLMClient:
     async def get_public_hub_info(self) -> dict:
         """Get Model Hub metadata: title, description, useful links (`GET /public/model_hub/info`)."""
         return await self._request("GET", "/public/model_hub/info")
+
+    async def get_model_cost_map(self) -> dict:
+        """Get LiteLLM's static model cost / capability map (`GET /public/litellm_model_cost_map`)."""
+        return await self._request("GET", "/public/litellm_model_cost_map")

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -583,3 +583,10 @@ class LiteLLMClient:
         return await self._request(
             "POST", f"/key/{key}/reset_spend", json={"reset_to": reset_to}
         )
+
+    async def key_health(self) -> dict:
+        """Probe the health of the caller's key (`POST /key/health`).
+
+        Returns connectivity / permission status for the bearer key. No body.
+        """
+        return await self._request("POST", "/key/health")

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -336,3 +336,40 @@ class LiteLLMClient:
     async def delete_credential(self, credential_name: str) -> dict:
         """Delete a credential (`DELETE /credentials/{credential_name}`)."""
         return await self._request("DELETE", f"/credentials/{credential_name}")
+
+    # ── Key operations ──
+
+    async def list_keys(
+        self,
+        page: Optional[int] = None,
+        size: Optional[int] = None,
+        user_id: Optional[str] = None,
+        team_id: Optional[str] = None,
+        organization_id: Optional[str] = None,
+        key_alias: Optional[str] = None,
+        return_full_object: Optional[bool] = None,
+        include_team_keys: Optional[bool] = None,
+        sort_by: Optional[str] = None,
+        sort_order: Optional[str] = None,
+    ) -> dict:
+        """List virtual keys (`GET /key/list`).
+
+        Returns a paginated payload. All filter args are optional.
+        """
+        params = {
+            k: v
+            for k, v in {
+                "page": page,
+                "size": size,
+                "user_id": user_id,
+                "team_id": team_id,
+                "organization_id": organization_id,
+                "key_alias": key_alias,
+                "return_full_object": return_full_object,
+                "include_team_keys": include_team_keys,
+                "sort_by": sort_by,
+                "sort_order": sort_order,
+            }.items()
+            if v is not None
+        }
+        return await self._request("GET", "/key/list", params=params or None)

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -163,3 +163,23 @@ class LiteLLMClient:
             "model_info": model_info,
         }
         return await self._request("POST", "/model/new", json=body)
+
+    async def update_model(
+        self,
+        model_id: str,
+        model_name: Optional[str] = None,
+        litellm_params: Optional[dict] = None,
+        model_info: Optional[dict] = None,
+    ) -> dict:
+        """Patch an existing model deployment (`PATCH /model/{model_id}/update`).
+
+        All body fields are optional; only those passed will be sent.
+        """
+        body: dict[str, Any] = {}
+        if model_name is not None:
+            body["model_name"] = model_name
+        if litellm_params is not None:
+            body["litellm_params"] = litellm_params
+        if model_info is not None:
+            body["model_info"] = model_info
+        return await self._request("PATCH", f"/model/{model_id}/update", json=body)

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -282,3 +282,7 @@ class LiteLLMClient:
         included — use `get_credential` for details.
         """
         return await self._request("GET", "/credentials")
+
+    async def get_credential(self, credential_name: str) -> dict:
+        """Get a credential by name (`GET /credentials/by_name/{credential_name}`)."""
+        return await self._request("GET", f"/credentials/by_name/{credential_name}")

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -132,6 +132,12 @@ class LiteLLMClient:
         """Get a single model entry from the OpenAI-compatible models endpoint.
 
         Calls `GET /v1/models/{model_id}`.
+
+        Note: LiteLLM only resolves `model_id` against router-registered
+        deployments here, *not* the union returned by `GET /v1/models`. Calling
+        with a passthrough id from `list_models()` will 404 — that's upstream
+        behavior, not a wrapper bug. Use `get_model_info()` for the admin-side
+        view that includes router deployments by their internal litellm id.
         """
         return await self._request("GET", f"/v1/models/{model_id}")
 
@@ -321,17 +327,19 @@ class LiteLLMClient:
     ) -> dict:
         """Update a credential (`PATCH /credentials/{credential_name}`).
 
-        The CredentialItem schema requires all three fields. Path id and body
-        `credential_name` should match.
+        Despite the PATCH verb, this is *not* a partial update — the upstream
+        `CredentialItem` schema requires all three fields. Callers must
+        re-send the full current state of `credential_info` and
+        `credential_values` (e.g. via `get_credential(..., verbosity='full')`),
+        not just the keys they want to change. Path id and body `credential_name`
+        should match.
         """
         body = {
             "credential_name": credential_name,
             "credential_info": credential_info,
             "credential_values": credential_values,
         }
-        return await self._request(
-            "PATCH", f"/credentials/{credential_name}", json=body
-        )
+        return await self._request("PATCH", f"/credentials/{credential_name}", json=body)
 
     async def delete_credential(self, credential_name: str) -> dict:
         """Delete a credential (`DELETE /credentials/{credential_name}`)."""
@@ -545,9 +553,7 @@ class LiteLLMClient:
             {"new_master_key": new_master_key, "duration": duration},
             extras,
         )
-        return await self._request(
-            "POST", f"/key/{key}/regenerate", json=body or None
-        )
+        return await self._request("POST", f"/key/{key}/regenerate", json=body or None)
 
     async def set_key_blocked(self, key: str, blocked: bool) -> dict:
         """Block or unblock a virtual key.
@@ -580,9 +586,7 @@ class LiteLLMClient:
         `reset_to` defaults to 0.0 (typical use); pass a positive value to set
         a starting balance.
         """
-        return await self._request(
-            "POST", f"/key/{key}/reset_spend", json={"reset_to": reset_to}
-        )
+        return await self._request("POST", f"/key/{key}/reset_spend", json={"reset_to": reset_to})
 
     async def key_health(self) -> dict:
         """Probe the health of the caller's key (`POST /key/health`).

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -332,3 +332,7 @@ class LiteLLMClient:
         return await self._request(
             "PATCH", f"/credentials/{credential_name}", json=body
         )
+
+    async def delete_credential(self, credential_name: str) -> dict:
+        """Delete a credential (`DELETE /credentials/{credential_name}`)."""
+        return await self._request("DELETE", f"/credentials/{credential_name}")

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -204,3 +204,12 @@ class LiteLLMClient:
     async def get_model_cost_map(self) -> dict:
         """Get LiteLLM's static model cost / capability map (`GET /public/litellm_model_cost_map`)."""
         return await self._request("GET", "/public/litellm_model_cost_map")
+
+    async def make_model_group_public(self, model_groups: list[str]) -> dict:
+        """Publish model groups to the public Model Hub (`POST /model_group/make_public`).
+
+        Replaces (not appends) the current set of published groups with `model_groups`.
+        """
+        return await self._request(
+            "POST", "/model_group/make_public", json={"model_groups": model_groups}
+        )

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -196,3 +196,7 @@ class LiteLLMClient:
     async def list_public_models(self) -> Any:
         """List models published to the public Model Hub (`GET /public/model_hub`)."""
         return await self._request("GET", "/public/model_hub")
+
+    async def get_public_hub_info(self) -> dict:
+        """Get Model Hub metadata: title, description, useful links (`GET /public/model_hub/info`)."""
+        return await self._request("GET", "/public/model_hub/info")

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -127,3 +127,10 @@ class LiteLLMClient:
         if isinstance(payload, list):
             return payload
         return []
+
+    async def get_model(self, model_id: str) -> dict:
+        """Get a single model entry from the OpenAI-compatible models endpoint.
+
+        Calls `GET /v1/models/{model_id}`.
+        """
+        return await self._request("GET", f"/v1/models/{model_id}")

--- a/src/server.py
+++ b/src/server.py
@@ -145,6 +145,21 @@ async def add_model(
 
 
 @mcp.tool()
+async def update_model(
+    model_id: str,
+    model_name: Optional[str] = None,
+    litellm_params: Optional[dict] = None,
+    model_info: Optional[dict] = None,
+) -> dict:
+    """Patch an existing model deployment (`PATCH /model/{model_id}/update`).
+
+    Only the provided fields are sent. The deployment id (`model_id`) goes in
+    the path, not the body.
+    """
+    return await get_client().update_model(model_id, model_name, litellm_params, model_info)
+
+
+@mcp.tool()
 async def get_model_info(litellm_model_id: Optional[str] = None) -> dict:
     """Get admin-side model info — full deployment details (`GET /model/info`).
 

--- a/src/server.py
+++ b/src/server.py
@@ -127,6 +127,21 @@ async def get_model(model_id: str, verbosity: str = "standard") -> dict:
     return _filter_response(model, "model", verbosity)
 
 
+@mcp.tool()
+async def get_model_info(litellm_model_id: Optional[str] = None) -> dict:
+    """Get admin-side model info — full deployment details (`GET /model/info`).
+
+    Returns the upstream payload as-is (no verbosity filtering — this endpoint
+    surfaces operational details like litellm_params and model_info that
+    callers usually want to see in full).
+
+    Args:
+        litellm_model_id: Optional litellm internal model id to filter to a
+            single deployment.
+    """
+    return await get_client().get_model_info(litellm_model_id)
+
+
 # ── Entrypoint ──
 
 

--- a/src/server.py
+++ b/src/server.py
@@ -277,6 +277,12 @@ async def update_model_access_group(
 
 
 @mcp.tool()
+async def delete_model_access_group(access_group: str) -> dict:
+    """Delete a model access group by name (`DELETE /access_group/{access_group}/delete`)."""
+    return await get_client().delete_model_access_group(access_group)
+
+
+@mcp.tool()
 async def get_model_info(litellm_model_id: Optional[str] = None) -> dict:
     """Get admin-side model info — full deployment details (`GET /model/info`).
 

--- a/src/server.py
+++ b/src/server.py
@@ -259,6 +259,24 @@ async def create_model_access_group(
 
 
 @mcp.tool()
+async def update_model_access_group(
+    access_group: str,
+    model_names: Optional[list[str]] = None,
+    model_ids: Optional[list[str]] = None,
+) -> dict:
+    """Update membership of a model access group (`PUT /access_group/{access_group}/update`).
+
+    Replaces (not appends) the current membership.
+
+    Args:
+        access_group: target access group name.
+        model_names: optional new list of model_name aliases.
+        model_ids: optional new list of deployment ids.
+    """
+    return await get_client().update_model_access_group(access_group, model_names, model_ids)
+
+
+@mcp.tool()
 async def get_model_info(litellm_model_id: Optional[str] = None) -> dict:
     """Get admin-side model info — full deployment details (`GET /model/info`).
 

--- a/src/server.py
+++ b/src/server.py
@@ -562,6 +562,17 @@ async def delete_keys(
 
 
 @mcp.tool()
+async def reset_key_spend(key: str, reset_to: float = 0.0) -> dict:
+    """Reset a key's accumulated spend (`POST /key/{key}/reset_spend`).
+
+    Args:
+        key: virtual key value.
+        reset_to: target spend (defaults to 0.0).
+    """
+    return await get_client().reset_key_spend(key, reset_to)
+
+
+@mcp.tool()
 async def get_model_info(litellm_model_id: Optional[str] = None) -> dict:
     """Get admin-side model info — full deployment details (`GET /model/info`).
 

--- a/src/server.py
+++ b/src/server.py
@@ -398,6 +398,20 @@ async def list_keys(
 
 
 @mcp.tool()
+async def list_key_aliases(
+    page: Optional[int] = None,
+    size: Optional[int] = None,
+    search: Optional[str] = None,
+    team_id: Optional[str] = None,
+) -> dict:
+    """List key aliases (`GET /key/aliases`).
+
+    Lighter-weight than `list_keys`; returns only alias metadata.
+    """
+    return await get_client().list_key_aliases(page, size, search, team_id)
+
+
+@mcp.tool()
 async def get_model_info(litellm_model_id: Optional[str] = None) -> dict:
     """Get admin-side model info — full deployment details (`GET /model/info`).
 

--- a/src/server.py
+++ b/src/server.py
@@ -128,6 +128,23 @@ async def get_model(model_id: str, verbosity: str = "standard") -> dict:
 
 
 @mcp.tool()
+async def add_model(
+    model_name: str,
+    litellm_params: dict,
+    model_info: dict,
+) -> dict:
+    """Register a new model deployment (`POST /model/new`).
+
+    Args:
+        model_name: client-facing alias (e.g. `gpt-4o`).
+        litellm_params: provider routing dict (e.g.
+            `{"model": "openai/gpt-4o", "api_key": "sk-..."}`).
+        model_info: deployment metadata (e.g. `{"id": "...", "db_model": false}`).
+    """
+    return await get_client().add_model(model_name, litellm_params, model_info)
+
+
+@mcp.tool()
 async def get_model_info(litellm_model_id: Optional[str] = None) -> dict:
     """Get admin-side model info — full deployment details (`GET /model/info`).
 

--- a/src/server.py
+++ b/src/server.py
@@ -573,6 +573,15 @@ async def reset_key_spend(key: str, reset_to: float = 0.0) -> dict:
 
 
 @mcp.tool()
+async def key_health() -> dict:
+    """Probe the health of the caller's key (`POST /key/health`).
+
+    Returns connectivity / permission status for the bearer key.
+    """
+    return await get_client().key_health()
+
+
+@mcp.tool()
 async def get_model_info(litellm_model_id: Optional[str] = None) -> dict:
     """Get admin-side model info — full deployment details (`GET /model/info`).
 

--- a/src/server.py
+++ b/src/server.py
@@ -320,6 +320,26 @@ async def get_credential_by_model(model_id: str, verbosity: str = "standard") ->
 
 
 @mcp.tool()
+async def create_credential(
+    credential_name: str,
+    credential_info: dict,
+    credential_values: Optional[dict] = None,
+    model_id: Optional[str] = None,
+) -> dict:
+    """Create a credential (`POST /credentials`).
+
+    Args:
+        credential_name: identifier for the new credential.
+        credential_info: metadata dict (e.g. `{"custom_llm_provider": "openai"}`).
+        credential_values: raw credential values (e.g. `{"api_key": "sk-..."}`).
+        model_id: bind to existing deployment instead of providing values.
+    """
+    return await get_client().create_credential(
+        credential_name, credential_info, credential_values, model_id
+    )
+
+
+@mcp.tool()
 async def get_model_info(litellm_model_id: Optional[str] = None) -> dict:
     """Get admin-side model info — full deployment details (`GET /model/info`).
 

--- a/src/server.py
+++ b/src/server.py
@@ -170,6 +170,17 @@ async def delete_model(model_id: str) -> dict:
 
 
 @mcp.tool()
+async def list_public_models(verbosity: str = "standard") -> Any:
+    """List models published to the public Model Hub (`GET /public/model_hub`).
+
+    Args:
+        verbosity: 'minimal' / 'standard' / 'full'.
+    """
+    payload = await get_client().list_public_models()
+    return _filter_response(payload, "public_hub", verbosity)
+
+
+@mcp.tool()
 async def get_model_info(litellm_model_id: Optional[str] = None) -> dict:
     """Get admin-side model info — full deployment details (`GET /model/info`).
 

--- a/src/server.py
+++ b/src/server.py
@@ -152,6 +152,10 @@ async def list_models(verbosity: str = "standard") -> list[dict]:
 async def get_model(model_id: str, verbosity: str = "standard") -> dict:
     """Get a single model entry by id (`GET /v1/models/{model_id}`).
 
+    Note: this endpoint only resolves router-registered deployments. Passthrough
+    ids returned by `list_models()` will 404 — for admin-side info on router
+    deployments, use `get_model_info()` instead.
+
     Args:
         model_id: The OpenAI-style model id (e.g. `gpt-4o`).
         verbosity: 'minimal' / 'standard' / 'full'.
@@ -380,16 +384,17 @@ async def update_credential(
 ) -> dict:
     """Update a credential (`PATCH /credentials/{credential_name}`).
 
-    The upstream CredentialItem schema requires all three fields.
+    Despite the PATCH verb, the upstream CredentialItem schema requires all
+    three fields — this is a full replace, not a partial update. Fetch the
+    current state with `get_credential(..., verbosity='full')` first if you
+    only want to change one field.
 
     Args:
         credential_name: name of credential to update.
-        credential_info: full metadata dict.
-        credential_values: full credential values dict.
+        credential_info: full metadata dict (will replace existing).
+        credential_values: full credential values dict (will replace existing).
     """
-    return await get_client().update_credential(
-        credential_name, credential_info, credential_values
-    )
+    return await get_client().update_credential(credential_name, credential_info, credential_values)
 
 
 @mcp.tool()
@@ -421,8 +426,16 @@ async def list_keys(
         verbosity: 'minimal' / 'standard' / 'full'.
     """
     payload = await get_client().list_keys(
-        page, size, user_id, team_id, organization_id, key_alias,
-        return_full_object, include_team_keys, sort_by, sort_order,
+        page,
+        size,
+        user_id,
+        team_id,
+        organization_id,
+        key_alias,
+        return_full_object,
+        include_team_keys,
+        sort_by,
+        sort_order,
     )
     if isinstance(payload, dict) and "keys" in payload:
         payload = dict(payload)
@@ -493,9 +506,19 @@ async def generate_key(
         extras: any other GenerateKeyRequest field (merged last).
     """
     return await get_client().generate_key(
-        key_alias, duration, models, max_budget, budget_duration,
-        user_id, team_id, tpm_limit, rpm_limit, metadata, guardrails,
-        blocked, extras,
+        key_alias,
+        duration,
+        models,
+        max_budget,
+        budget_duration,
+        user_id,
+        team_id,
+        tpm_limit,
+        rpm_limit,
+        metadata,
+        guardrails,
+        blocked,
+        extras,
     )
 
 
@@ -521,9 +544,19 @@ async def generate_service_account_key(
     service account (no human user binding required).
     """
     return await get_client().generate_service_account_key(
-        key_alias, duration, models, max_budget, budget_duration,
-        user_id, team_id, tpm_limit, rpm_limit, metadata, guardrails,
-        blocked, extras,
+        key_alias,
+        duration,
+        models,
+        max_budget,
+        budget_duration,
+        user_id,
+        team_id,
+        tpm_limit,
+        rpm_limit,
+        metadata,
+        guardrails,
+        blocked,
+        extras,
     )
 
 
@@ -548,8 +581,18 @@ async def update_key(
     for less-common UpdateKeyRequest fields not surfaced as named args.
     """
     return await get_client().update_key(
-        key, key_alias, duration, models, max_budget, budget_duration,
-        tpm_limit, rpm_limit, metadata, guardrails, blocked, extras,
+        key,
+        key_alias,
+        duration,
+        models,
+        max_budget,
+        budget_duration,
+        tpm_limit,
+        rpm_limit,
+        metadata,
+        guardrails,
+        blocked,
+        extras,
     )
 
 

--- a/src/server.py
+++ b/src/server.py
@@ -243,6 +243,22 @@ async def get_model_access_group(access_group: str, verbosity: str = "standard")
 
 
 @mcp.tool()
+async def create_model_access_group(
+    access_group: str,
+    model_names: Optional[list[str]] = None,
+    model_ids: Optional[list[str]] = None,
+) -> dict:
+    """Create a new model access group (`POST /access_group/new`).
+
+    Args:
+        access_group: name of the new group.
+        model_names: optional list of model_name aliases to include.
+        model_ids: optional list of deployment ids to include.
+    """
+    return await get_client().create_model_access_group(access_group, model_names, model_ids)
+
+
+@mcp.tool()
 async def get_model_info(litellm_model_id: Optional[str] = None) -> dict:
     """Get admin-side model info — full deployment details (`GET /model/info`).
 

--- a/src/server.py
+++ b/src/server.py
@@ -412,6 +412,18 @@ async def list_key_aliases(
 
 
 @mcp.tool()
+async def get_key_info(key: Optional[str] = None, verbosity: str = "standard") -> dict:
+    """Get info about a key (`GET /key/info`).
+
+    Args:
+        key: Optional key value. If omitted, returns info about the caller's own key.
+        verbosity: 'minimal' / 'standard' / 'full'.
+    """
+    payload = await get_client().get_key_info(key)
+    return _filter_response(payload, "key", verbosity)
+
+
+@mcp.tool()
 async def get_model_info(litellm_model_id: Optional[str] = None) -> dict:
     """Get admin-side model info — full deployment details (`GET /model/info`).
 

--- a/src/server.py
+++ b/src/server.py
@@ -25,6 +25,39 @@ RESPONSE_FIELDS: dict[str, dict[str, Optional[list[str]]]] = {
         "standard": ["id", "object", "owned_by", "created"],
         "full": None,
     },
+    "access_group": {
+        "minimal": ["access_group"],
+        "standard": ["access_group", "model_names", "model_ids"],
+        "full": None,
+    },
+    "credential": {
+        # 'standard' deliberately omits credential_values to avoid leaking
+        # secrets into agent transcripts. Use verbosity='full' to inspect them.
+        "minimal": ["credential_name"],
+        "standard": ["credential_name", "credential_info"],
+        "full": None,
+    },
+    "key": {
+        "minimal": ["token", "key_name", "key_alias"],
+        "standard": [
+            "token",
+            "key_name",
+            "key_alias",
+            "spend",
+            "max_budget",
+            "models",
+            "user_id",
+            "team_id",
+            "expires",
+            "blocked",
+        ],
+        "full": None,
+    },
+    "public_hub": {
+        "minimal": ["model_group"],
+        "standard": ["model_group", "providers", "max_input_tokens", "max_output_tokens"],
+        "full": None,
+    },
 }
 
 VALID_VERBOSITY_LEVELS = {"minimal", "standard", "full"}

--- a/src/server.py
+++ b/src/server.py
@@ -181,6 +181,12 @@ async def list_public_models(verbosity: str = "standard") -> Any:
 
 
 @mcp.tool()
+async def get_public_hub_info() -> dict:
+    """Get Model Hub metadata — title, description, useful links (`GET /public/model_hub/info`)."""
+    return await get_client().get_public_hub_info()
+
+
+@mcp.tool()
 async def get_model_info(litellm_model_id: Optional[str] = None) -> dict:
     """Get admin-side model info — full deployment details (`GET /model/info`).
 

--- a/src/server.py
+++ b/src/server.py
@@ -308,6 +308,18 @@ async def get_credential(credential_name: str, verbosity: str = "standard") -> d
 
 
 @mcp.tool()
+async def get_credential_by_model(model_id: str, verbosity: str = "standard") -> dict:
+    """Get the credential bound to a deployment (`GET /credentials/by_model/{model_id}`).
+
+    Args:
+        model_id: deployment id.
+        verbosity: 'minimal' / 'standard' / 'full'.
+    """
+    payload = await get_client().get_credential_by_model(model_id)
+    return _filter_response(payload, "credential", verbosity)
+
+
+@mcp.tool()
 async def get_model_info(litellm_model_id: Optional[str] = None) -> dict:
     """Get admin-side model info — full deployment details (`GET /model/info`).
 

--- a/src/server.py
+++ b/src/server.py
@@ -495,6 +495,32 @@ async def generate_service_account_key(
 
 
 @mcp.tool()
+async def update_key(
+    key: str,
+    key_alias: Optional[str] = None,
+    duration: Optional[str] = None,
+    models: Optional[list[str]] = None,
+    max_budget: Optional[float] = None,
+    budget_duration: Optional[str] = None,
+    tpm_limit: Optional[int] = None,
+    rpm_limit: Optional[int] = None,
+    metadata: Optional[dict] = None,
+    guardrails: Optional[list[str]] = None,
+    blocked: Optional[bool] = None,
+    extras: Optional[dict] = None,
+) -> dict:
+    """Update a virtual key (`POST /key/update`).
+
+    Only `key` is required. All other fields are merged sparsely. Use `extras`
+    for less-common UpdateKeyRequest fields not surfaced as named args.
+    """
+    return await get_client().update_key(
+        key, key_alias, duration, models, max_budget, budget_duration,
+        tpm_limit, rpm_limit, metadata, guardrails, blocked, extras,
+    )
+
+
+@mcp.tool()
 async def get_model_info(litellm_model_id: Optional[str] = None) -> dict:
     """Get admin-side model info — full deployment details (`GET /model/info`).
 

--- a/src/server.py
+++ b/src/server.py
@@ -366,6 +366,38 @@ async def delete_credential(credential_name: str) -> dict:
 
 
 @mcp.tool()
+async def list_keys(
+    page: Optional[int] = None,
+    size: Optional[int] = None,
+    user_id: Optional[str] = None,
+    team_id: Optional[str] = None,
+    organization_id: Optional[str] = None,
+    key_alias: Optional[str] = None,
+    return_full_object: Optional[bool] = None,
+    include_team_keys: Optional[bool] = None,
+    sort_by: Optional[str] = None,
+    sort_order: Optional[str] = None,
+    verbosity: str = "standard",
+) -> dict:
+    """List virtual keys (`GET /key/list`).
+
+    All filter args are optional. The response is the full paginated object;
+    only `keys` items are filtered by verbosity if it's a list.
+
+    Args:
+        verbosity: 'minimal' / 'standard' / 'full'.
+    """
+    payload = await get_client().list_keys(
+        page, size, user_id, team_id, organization_id, key_alias,
+        return_full_object, include_team_keys, sort_by, sort_order,
+    )
+    if isinstance(payload, dict) and "keys" in payload:
+        payload = dict(payload)
+        payload["keys"] = _filter_response(payload["keys"], "key", verbosity)
+    return payload
+
+
+@mcp.tool()
 async def get_model_info(litellm_model_id: Optional[str] = None) -> dict:
     """Get admin-side model info — full deployment details (`GET /model/info`).
 

--- a/src/server.py
+++ b/src/server.py
@@ -340,6 +340,26 @@ async def create_credential(
 
 
 @mcp.tool()
+async def update_credential(
+    credential_name: str,
+    credential_info: dict,
+    credential_values: dict,
+) -> dict:
+    """Update a credential (`PATCH /credentials/{credential_name}`).
+
+    The upstream CredentialItem schema requires all three fields.
+
+    Args:
+        credential_name: name of credential to update.
+        credential_info: full metadata dict.
+        credential_values: full credential values dict.
+    """
+    return await get_client().update_credential(
+        credential_name, credential_info, credential_values
+    )
+
+
+@mcp.tool()
 async def get_model_info(litellm_model_id: Optional[str] = None) -> dict:
     """Get admin-side model info — full deployment details (`GET /model/info`).
 

--- a/src/server.py
+++ b/src/server.py
@@ -187,6 +187,16 @@ async def get_public_hub_info() -> dict:
 
 
 @mcp.tool()
+async def get_model_cost_map() -> dict:
+    """Get the LiteLLM static model cost / capability map (`GET /public/litellm_model_cost_map`).
+
+    Large response (~1MB). Useful for the admin agent to look up token pricing
+    and context windows without an outbound call.
+    """
+    return await get_client().get_model_cost_map()
+
+
+@mcp.tool()
 async def get_model_info(litellm_model_id: Optional[str] = None) -> dict:
     """Get admin-side model info — full deployment details (`GET /model/info`).
 

--- a/src/server.py
+++ b/src/server.py
@@ -536,6 +536,19 @@ async def regenerate_key(
 
 
 @mcp.tool()
+async def set_key_blocked(key: str, blocked: bool) -> dict:
+    """Block or unblock a virtual key.
+
+    Routes to `POST /key/block` when `blocked=True`, else `POST /key/unblock`.
+
+    Args:
+        key: virtual key value.
+        blocked: True to block, False to unblock.
+    """
+    return await get_client().set_key_blocked(key, blocked)
+
+
+@mcp.tool()
 async def get_model_info(litellm_model_id: Optional[str] = None) -> dict:
     """Get admin-side model info — full deployment details (`GET /model/info`).
 

--- a/src/server.py
+++ b/src/server.py
@@ -283,6 +283,19 @@ async def delete_model_access_group(access_group: str) -> dict:
 
 
 @mcp.tool()
+async def list_credentials(verbosity: str = "standard") -> Any:
+    """List provider credentials (`GET /credentials`).
+
+    Credential values are not included; use `get_credential` for details.
+
+    Args:
+        verbosity: 'minimal' / 'standard' / 'full'.
+    """
+    payload = await get_client().list_credentials()
+    return _filter_response(payload, "credential", verbosity)
+
+
+@mcp.tool()
 async def get_model_info(litellm_model_id: Optional[str] = None) -> dict:
     """Get admin-side model info — full deployment details (`GET /model/info`).
 

--- a/src/server.py
+++ b/src/server.py
@@ -160,6 +160,16 @@ async def update_model(
 
 
 @mcp.tool()
+async def delete_model(model_id: str) -> dict:
+    """Delete a model deployment (`POST /model/delete`).
+
+    Args:
+        model_id: deployment id (sent in body as `{"id": model_id}`).
+    """
+    return await get_client().delete_model(model_id)
+
+
+@mcp.tool()
 async def get_model_info(litellm_model_id: Optional[str] = None) -> dict:
     """Get admin-side model info — full deployment details (`GET /model/info`).
 

--- a/src/server.py
+++ b/src/server.py
@@ -209,6 +209,17 @@ async def make_model_group_public(model_groups: list[str]) -> dict:
 
 
 @mcp.tool()
+async def update_model_hub_links(useful_links: dict) -> dict:
+    """Update the Model Hub useful-links section (`POST /model_hub/update_useful_links`).
+
+    Args:
+        useful_links: free-form mapping of label → URL
+            (e.g. `{"Documentation": "https://..."}`).
+    """
+    return await get_client().update_model_hub_links(useful_links)
+
+
+@mcp.tool()
 async def get_model_info(litellm_model_id: Optional[str] = None) -> dict:
     """Get admin-side model info — full deployment details (`GET /model/info`).
 

--- a/src/server.py
+++ b/src/server.py
@@ -197,6 +197,18 @@ async def get_model_cost_map() -> dict:
 
 
 @mcp.tool()
+async def make_model_group_public(model_groups: list[str]) -> dict:
+    """Publish model groups to the public Model Hub (`POST /model_group/make_public`).
+
+    Replaces (not appends) the current set of published groups.
+
+    Args:
+        model_groups: list of model_name strings to publish.
+    """
+    return await get_client().make_model_group_public(model_groups)
+
+
+@mcp.tool()
 async def get_model_info(litellm_model_id: Optional[str] = None) -> dict:
     """Get admin-side model info — full deployment details (`GET /model/info`).
 

--- a/src/server.py
+++ b/src/server.py
@@ -220,6 +220,17 @@ async def update_model_hub_links(useful_links: dict) -> dict:
 
 
 @mcp.tool()
+async def list_model_access_groups(verbosity: str = "standard") -> Any:
+    """List all model access groups (`GET /access_group/list`).
+
+    Args:
+        verbosity: 'minimal' / 'standard' / 'full'.
+    """
+    payload = await get_client().list_model_access_groups()
+    return _filter_response(payload, "access_group", verbosity)
+
+
+@mcp.tool()
 async def get_model_info(litellm_model_id: Optional[str] = None) -> dict:
     """Get admin-side model info — full deployment details (`GET /model/info`).
 

--- a/src/server.py
+++ b/src/server.py
@@ -521,6 +521,21 @@ async def update_key(
 
 
 @mcp.tool()
+async def regenerate_key(
+    key: str,
+    new_master_key: Optional[str] = None,
+    duration: Optional[str] = None,
+    extras: Optional[dict] = None,
+) -> dict:
+    """Regenerate a virtual key (`POST /key/{key}/regenerate`).
+
+    Returns the new key value. Body is optional; pass `extras` to atomically
+    update RegenerateKeyRequest fields on the new key.
+    """
+    return await get_client().regenerate_key(key, new_master_key, duration, extras)
+
+
+@mcp.tool()
 async def get_model_info(litellm_model_id: Optional[str] = None) -> dict:
     """Get admin-side model info — full deployment details (`GET /model/info`).
 

--- a/src/server.py
+++ b/src/server.py
@@ -467,6 +467,34 @@ async def generate_key(
 
 
 @mcp.tool()
+async def generate_service_account_key(
+    key_alias: Optional[str] = None,
+    duration: Optional[str] = None,
+    models: Optional[list[str]] = None,
+    max_budget: Optional[float] = None,
+    budget_duration: Optional[str] = None,
+    user_id: Optional[str] = None,
+    team_id: Optional[str] = None,
+    tpm_limit: Optional[int] = None,
+    rpm_limit: Optional[int] = None,
+    metadata: Optional[dict] = None,
+    guardrails: Optional[list[str]] = None,
+    blocked: Optional[bool] = None,
+    extras: Optional[dict] = None,
+) -> dict:
+    """Generate a service-account virtual key (`POST /key/service-account/generate`).
+
+    Same body shape as `generate_key`. Upstream tags the resulting key as a
+    service account (no human user binding required).
+    """
+    return await get_client().generate_service_account_key(
+        key_alias, duration, models, max_budget, budget_duration,
+        user_id, team_id, tpm_limit, rpm_limit, metadata, guardrails,
+        blocked, extras,
+    )
+
+
+@mcp.tool()
 async def get_model_info(litellm_model_id: Optional[str] = None) -> dict:
     """Get admin-side model info — full deployment details (`GET /model/info`).
 

--- a/src/server.py
+++ b/src/server.py
@@ -360,6 +360,12 @@ async def update_credential(
 
 
 @mcp.tool()
+async def delete_credential(credential_name: str) -> dict:
+    """Delete a credential (`DELETE /credentials/{credential_name}`)."""
+    return await get_client().delete_credential(credential_name)
+
+
+@mcp.tool()
 async def get_model_info(litellm_model_id: Optional[str] = None) -> dict:
     """Get admin-side model info — full deployment details (`GET /model/info`).
 

--- a/src/server.py
+++ b/src/server.py
@@ -549,6 +549,19 @@ async def set_key_blocked(key: str, blocked: bool) -> dict:
 
 
 @mcp.tool()
+async def delete_keys(
+    keys: Optional[list[str]] = None,
+    key_aliases: Optional[list[str]] = None,
+) -> dict:
+    """Batch-delete virtual keys (`POST /key/delete`).
+
+    Provide either `keys` (raw values) or `key_aliases` (alias names); at
+    least one must be non-empty.
+    """
+    return await get_client().delete_keys(keys, key_aliases)
+
+
+@mcp.tool()
 async def get_model_info(litellm_model_id: Optional[str] = None) -> dict:
     """Get admin-side model info — full deployment details (`GET /model/info`).
 

--- a/src/server.py
+++ b/src/server.py
@@ -115,6 +115,18 @@ async def list_models(verbosity: str = "standard") -> list[dict]:
     return _filter_response(models, "model", verbosity)
 
 
+@mcp.tool()
+async def get_model(model_id: str, verbosity: str = "standard") -> dict:
+    """Get a single model entry by id (`GET /v1/models/{model_id}`).
+
+    Args:
+        model_id: The OpenAI-style model id (e.g. `gpt-4o`).
+        verbosity: 'minimal' / 'standard' / 'full'.
+    """
+    model = await get_client().get_model(model_id)
+    return _filter_response(model, "model", verbosity)
+
+
 # ── Entrypoint ──
 
 

--- a/src/server.py
+++ b/src/server.py
@@ -231,6 +231,18 @@ async def list_model_access_groups(verbosity: str = "standard") -> Any:
 
 
 @mcp.tool()
+async def get_model_access_group(access_group: str, verbosity: str = "standard") -> dict:
+    """Get a single model access group by name (`GET /access_group/{access_group}/info`).
+
+    Args:
+        access_group: access group name (e.g. `engineering`).
+        verbosity: 'minimal' / 'standard' / 'full'.
+    """
+    payload = await get_client().get_model_access_group(access_group)
+    return _filter_response(payload, "access_group", verbosity)
+
+
+@mcp.tool()
 async def get_model_info(litellm_model_id: Optional[str] = None) -> dict:
     """Get admin-side model info — full deployment details (`GET /model/info`).
 

--- a/src/server.py
+++ b/src/server.py
@@ -424,6 +424,49 @@ async def get_key_info(key: Optional[str] = None, verbosity: str = "standard") -
 
 
 @mcp.tool()
+async def generate_key(
+    key_alias: Optional[str] = None,
+    duration: Optional[str] = None,
+    models: Optional[list[str]] = None,
+    max_budget: Optional[float] = None,
+    budget_duration: Optional[str] = None,
+    user_id: Optional[str] = None,
+    team_id: Optional[str] = None,
+    tpm_limit: Optional[int] = None,
+    rpm_limit: Optional[int] = None,
+    metadata: Optional[dict] = None,
+    guardrails: Optional[list[str]] = None,
+    blocked: Optional[bool] = None,
+    extras: Optional[dict] = None,
+) -> dict:
+    """Generate a new virtual key (`POST /key/generate`).
+
+    Common fields are explicit args. Use `extras` for the ~30 less-common
+    fields in the upstream `GenerateKeyRequest` (see Swagger).
+
+    Args:
+        key_alias: human-readable alias.
+        duration: TTL like `30d`, `1h`.
+        models: model_name allowlist (or empty for all).
+        max_budget: spend cap (USD).
+        budget_duration: budget reset window (`30d`).
+        user_id: bind to user.
+        team_id: bind to team.
+        tpm_limit: tokens-per-minute cap.
+        rpm_limit: requests-per-minute cap.
+        metadata: free-form metadata.
+        guardrails: guardrail names to enforce.
+        blocked: create as blocked.
+        extras: any other GenerateKeyRequest field (merged last).
+    """
+    return await get_client().generate_key(
+        key_alias, duration, models, max_budget, budget_duration,
+        user_id, team_id, tpm_limit, rpm_limit, metadata, guardrails,
+        blocked, extras,
+    )
+
+
+@mcp.tool()
 async def get_model_info(litellm_model_id: Optional[str] = None) -> dict:
     """Get admin-side model info — full deployment details (`GET /model/info`).
 

--- a/src/server.py
+++ b/src/server.py
@@ -296,6 +296,18 @@ async def list_credentials(verbosity: str = "standard") -> Any:
 
 
 @mcp.tool()
+async def get_credential(credential_name: str, verbosity: str = "standard") -> dict:
+    """Get a credential by name (`GET /credentials/by_name/{credential_name}`).
+
+    Args:
+        credential_name: name of the stored credential.
+        verbosity: 'minimal' / 'standard' / 'full'.
+    """
+    payload = await get_client().get_credential(credential_name)
+    return _filter_response(payload, "credential", verbosity)
+
+
+@mcp.tool()
 async def get_model_info(litellm_model_id: Optional[str] = None) -> dict:
     """Get admin-side model info — full deployment details (`GET /model/info`).
 

--- a/tests/smoke.py
+++ b/tests/smoke.py
@@ -95,7 +95,7 @@ async def run() -> int:
                 results.append(("get_model", True, _summarize(payload)))
             except LiteLLMAPIError as e:
                 if e.status_code == 404:
-                    results.append(("get_model", True, f"404 (passthrough model — wrapper OK)"))
+                    results.append(("get_model", True, "404 (passthrough model — wrapper OK)"))
                 else:
                     results.append(("get_model", False, f"APIError {e.status_code}: {e}"))
         else:

--- a/tests/smoke.py
+++ b/tests/smoke.py
@@ -1,0 +1,192 @@
+"""Read-only live smoke test for litellm-mcp.
+
+Hits the GET / health endpoints against a running LiteLLM proxy to verify the
+wrapper paths, auth, and response shapes. Destructive operations (add/update/
+delete) are covered by unit tests with AsyncMock fixtures and exercised
+implicitly when the admin agent uses them — this script only reads.
+
+Run:
+
+    LITELLM_PROXY_URL=... LITELLM_API_KEY=... uv run python tests/smoke.py
+
+Exits 0 on full pass, 1 on any failure.
+"""
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+# Allow running as a script: add repo root to sys.path.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+def _load_env() -> None:
+    """Source ~/.claude/litellm.env if present and env not already set."""
+    if os.environ.get("LITELLM_API_KEY"):
+        return
+    env_file = Path.home() / ".claude" / "litellm.env"
+    if not env_file.exists():
+        return
+    for line in env_file.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
+
+
+# Load env vars before importing settings (which evaluates them at import time).
+_load_env()
+
+from src.config import settings  # noqa: E402
+from src.litellm_client import LiteLLMAPIError, LiteLLMClient  # noqa: E402
+
+
+async def _step(name: str, coro) -> tuple[str, bool, str]:
+    try:
+        result = await coro
+    except LiteLLMAPIError as e:
+        return (name, False, f"APIError {e.status_code}: {e}")
+    except Exception as e:
+        return (name, False, f"{type(e).__name__}: {e}")
+    summary = _summarize(result)
+    return (name, True, summary)
+
+
+def _summarize(result) -> str:
+    if result is None:
+        return "None"
+    if isinstance(result, list):
+        return f"list[{len(result)}]"
+    if isinstance(result, dict):
+        keys = list(result.keys())[:5]
+        return f"dict({', '.join(keys)}{'...' if len(result) > 5 else ''})"
+    return f"{type(result).__name__}"
+
+
+async def run() -> int:
+    if not settings.has_api_key:
+        print("LITELLM_API_KEY is not set", file=sys.stderr)
+        return 1
+
+    client = LiteLLMClient(
+        base_url=settings.proxy_url,
+        api_key=settings.get_api_key_value(),
+        timeout=settings.timeout_seconds,
+        max_retries=settings.max_retries,
+    )
+    print(f"→ {settings.proxy_url}\n")
+    results = []
+
+    try:
+        # Models family (3 read ops)
+        models = await client.list_models()
+        results.append(("list_models", True, _summarize(models)))
+        first_model_id = (
+            models[0]["id"] if isinstance(models, list) and models else None
+        )
+        if first_model_id:
+            # Note: /v1/models lists router + passthrough models, but
+            # /v1/models/{id} only resolves router-registered ids. 404 is
+            # acceptable when the first list item is a passthrough.
+            try:
+                payload = await client.get_model(first_model_id)
+                results.append(("get_model", True, _summarize(payload)))
+            except LiteLLMAPIError as e:
+                if e.status_code == 404:
+                    results.append(("get_model", True, f"404 (passthrough model — wrapper OK)"))
+                else:
+                    results.append(("get_model", False, f"APIError {e.status_code}: {e}"))
+        else:
+            results.append(("get_model", True, "skipped (no models)"))
+        results.append(await _step("get_model_info", client.get_model_info()))
+
+        # Model Hub family (3 read ops)
+        results.append(await _step("list_public_models", client.list_public_models()))
+        results.append(await _step("get_public_hub_info", client.get_public_hub_info()))
+        results.append(await _step("get_model_cost_map", client.get_model_cost_map()))
+
+        # Access Groups family (2 read ops)
+        ag_list = await client.list_model_access_groups()
+        results.append(("list_model_access_groups", True, _summarize(ag_list)))
+        first_ag = None
+        if isinstance(ag_list, list) and ag_list:
+            first_ag = ag_list[0] if isinstance(ag_list[0], str) else ag_list[0].get("access_group")
+        elif isinstance(ag_list, dict):
+            data = ag_list.get("data") or ag_list.get("access_groups") or []
+            if data:
+                first_ag = data[0] if isinstance(data[0], str) else data[0].get("access_group")
+        if first_ag:
+            results.append(
+                await _step("get_model_access_group", client.get_model_access_group(first_ag))
+            )
+        else:
+            results.append(("get_model_access_group", True, "skipped (no access groups)"))
+
+        # Credentials family (3 read ops)
+        creds = await client.list_credentials()
+        results.append(("list_credentials", True, _summarize(creds)))
+        first_cred = None
+        if isinstance(creds, list) and creds:
+            first_cred = creds[0].get("credential_name")
+        elif isinstance(creds, dict):
+            data = creds.get("credentials") or creds.get("data") or []
+            if data:
+                first_cred = data[0].get("credential_name")
+        if first_cred:
+            results.append(await _step("get_credential", client.get_credential(first_cred)))
+        else:
+            results.append(("get_credential", True, "skipped (no credentials)"))
+        if first_model_id:
+            try:
+                payload = await client.get_credential_by_model(first_model_id)
+                results.append(("get_credential_by_model", True, _summarize(payload)))
+            except LiteLLMAPIError as e:
+                # Many models have no bound credential entry — 404 is acceptable.
+                if e.status_code == 404:
+                    results.append(("get_credential_by_model", True, "404 (no bound cred)"))
+                else:
+                    results.append(("get_credential_by_model", False, f"APIError {e.status_code}: {e}"))
+        else:
+            results.append(("get_credential_by_model", True, "skipped (no models)"))
+
+        # Keys family (4 read ops)
+        keys_payload = await client.list_keys(size=5)
+        results.append(("list_keys", True, _summarize(keys_payload)))
+        results.append(await _step("list_key_aliases", client.list_key_aliases(size=5)))
+        # Pick a real virtual-key value to probe get_key_info; calling without
+        # one (or with the master key) 404s because the master key isn't a
+        # row in the LiteLLM_VerificationToken table.
+        first_virtual_key = None
+        if isinstance(keys_payload, dict):
+            keys_list = keys_payload.get("keys") or []
+            for k in keys_list:
+                if isinstance(k, dict) and k.get("token"):
+                    first_virtual_key = k["token"]
+                    break
+        if first_virtual_key:
+            results.append(await _step("get_key_info", client.get_key_info(first_virtual_key)))
+        else:
+            results.append(("get_key_info", True, "skipped (no virtual keys to probe)"))
+        results.append(await _step("key_health", client.key_health()))
+
+    finally:
+        await client.close()
+
+    # Report
+    print(f"{'Tool':<32} {'OK':<4} Detail")
+    print("─" * 72)
+    failed = 0
+    for name, ok, detail in results:
+        mark = "✓" if ok else "✗"
+        if not ok:
+            failed += 1
+        print(f"{name:<32} {mark:<4} {detail}")
+    print("─" * 72)
+    print(f"\n{len(results) - failed}/{len(results)} passed")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(run()))

--- a/tests/smoke.py
+++ b/tests/smoke.py
@@ -83,9 +83,7 @@ async def run() -> int:
         # Models family (3 read ops)
         models = await client.list_models()
         results.append(("list_models", True, _summarize(models)))
-        first_model_id = (
-            models[0]["id"] if isinstance(models, list) and models else None
-        )
+        first_model_id = models[0]["id"] if isinstance(models, list) and models else None
         if first_model_id:
             # Note: /v1/models lists router + passthrough models, but
             # /v1/models/{id} only resolves router-registered ids. 404 is
@@ -147,7 +145,9 @@ async def run() -> int:
                 if e.status_code == 404:
                     results.append(("get_credential_by_model", True, "404 (no bound cred)"))
                 else:
-                    results.append(("get_credential_by_model", False, f"APIError {e.status_code}: {e}"))
+                    results.append(
+                        ("get_credential_by_model", False, f"APIError {e.status_code}: {e}")
+                    )
         else:
             results.append(("get_credential_by_model", True, "skipped (no models)"))
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -290,6 +290,33 @@ class TestGetCredentialByModel:
         mock_client.get_credential_by_model.assert_awaited_once_with("abc-123")
 
 
+class TestCreateCredential:
+    @pytest.mark.asyncio
+    async def test_with_values(self, mock_client):
+        mock_client.create_credential.return_value = {"ok": True}
+        await src.server.create_credential(
+            "openai-prod",
+            {"custom_llm_provider": "openai"},
+            credential_values={"api_key": "sk-x"},
+        )
+        mock_client.create_credential.assert_awaited_once_with(
+            "openai-prod",
+            {"custom_llm_provider": "openai"},
+            {"api_key": "sk-x"},
+            None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_with_model_id(self, mock_client):
+        mock_client.create_credential.return_value = {"ok": True}
+        await src.server.create_credential(
+            "openai-prod", {"custom_llm_provider": "openai"}, model_id="abc-123"
+        )
+        mock_client.create_credential.assert_awaited_once_with(
+            "openai-prod", {"custom_llm_provider": "openai"}, None, "abc-123"
+        )
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -97,6 +97,23 @@ class TestGetModelInfo:
         mock_client.get_model_info.assert_awaited_once_with("abc-123")
 
 
+class TestAddModel:
+    @pytest.mark.asyncio
+    async def test_passes_full_body(self, mock_client):
+        mock_client.add_model.return_value = {"model_id": "abc-123"}
+        result = await src.server.add_model(
+            "gpt-4o",
+            {"model": "openai/gpt-4o", "api_key": "sk-x"},
+            {"id": "abc-123"},
+        )
+        assert result == {"model_id": "abc-123"}
+        mock_client.add_model.assert_awaited_once_with(
+            "gpt-4o",
+            {"model": "openai/gpt-4o", "api_key": "sk-x"},
+            {"id": "abc-123"},
+        )
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -266,6 +266,18 @@ class TestListCredentials:
         mock_client.list_credentials.assert_awaited_once()
 
 
+class TestGetCredential:
+    @pytest.mark.asyncio
+    async def test_passes_credential_name(self, mock_client):
+        mock_client.get_credential.return_value = {
+            "credential_name": "openai-prod",
+            "credential_info": {},
+        }
+        result = await src.server.get_credential("openai-prod", "full")
+        assert result["credential_name"] == "openai-prod"
+        mock_client.get_credential.assert_awaited_once_with("openai-prod")
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -463,6 +463,20 @@ class TestRegenerateKey:
         )
 
 
+class TestSetKeyBlocked:
+    @pytest.mark.asyncio
+    async def test_block(self, mock_client):
+        mock_client.set_key_blocked.return_value = {"ok": True}
+        await src.server.set_key_blocked("sk-x", True)
+        mock_client.set_key_blocked.assert_awaited_once_with("sk-x", True)
+
+    @pytest.mark.asyncio
+    async def test_unblock(self, mock_client):
+        mock_client.set_key_blocked.return_value = {"ok": True}
+        await src.server.set_key_blocked("sk-x", False)
+        mock_client.set_key_blocked.assert_awaited_once_with("sk-x", False)
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -447,6 +447,22 @@ class TestUpdateKey:
         assert call.args[11] == {"max_parallel_requests": 8}
 
 
+class TestRegenerateKey:
+    @pytest.mark.asyncio
+    async def test_no_body(self, mock_client):
+        mock_client.regenerate_key.return_value = {"key": "sk-new"}
+        await src.server.regenerate_key("sk-old")
+        mock_client.regenerate_key.assert_awaited_once_with("sk-old", None, None, None)
+
+    @pytest.mark.asyncio
+    async def test_with_extras(self, mock_client):
+        mock_client.regenerate_key.return_value = {"key": "sk-new"}
+        await src.server.regenerate_key("sk-old", extras={"max_budget": 100.0})
+        mock_client.regenerate_key.assert_awaited_once_with(
+            "sk-old", None, None, {"max_budget": 100.0}
+        )
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -56,6 +56,31 @@ class TestListModels:
         assert result[0]["id"] == "x"
 
 
+class TestGetModel:
+    @pytest.mark.asyncio
+    async def test_returns_model_dict(self, mock_client):
+        mock_client.get_model.return_value = {
+            "id": "gpt-4o",
+            "object": "model",
+            "owned_by": "openai",
+            "created": 0,
+        }
+        result = await src.server.get_model("gpt-4o", "standard")
+        assert result["id"] == "gpt-4o"
+        mock_client.get_model.assert_awaited_once_with("gpt-4o")
+
+    @pytest.mark.asyncio
+    async def test_minimal_strips_fields(self, mock_client):
+        mock_client.get_model.return_value = {
+            "id": "gpt-4o",
+            "object": "model",
+            "owned_by": "openai",
+            "created": 1,
+        }
+        result = await src.server.get_model("gpt-4o", "minimal")
+        assert result == {"id": "gpt-4o"}
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -491,6 +491,20 @@ class TestDeleteKeys:
         mock_client.delete_keys.assert_awaited_once_with(None, ["prod-bot"])
 
 
+class TestResetKeySpend:
+    @pytest.mark.asyncio
+    async def test_default_zero(self, mock_client):
+        mock_client.reset_key_spend.return_value = {"ok": True}
+        await src.server.reset_key_spend("sk-x")
+        mock_client.reset_key_spend.assert_awaited_once_with("sk-x", 0.0)
+
+    @pytest.mark.asyncio
+    async def test_explicit_value(self, mock_client):
+        mock_client.reset_key_spend.return_value = {"ok": True}
+        await src.server.reset_key_spend("sk-x", 5.5)
+        mock_client.reset_key_spend.assert_awaited_once_with("sk-x", 5.5)
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -154,6 +154,16 @@ class TestListPublicModels:
         mock_client.list_public_models.assert_awaited_once()
 
 
+class TestGetPublicHubInfo:
+    @pytest.mark.asyncio
+    async def test_passthrough(self, mock_client):
+        payload = {"title": "Tetra Models", "description": "...", "useful_links": {}}
+        mock_client.get_public_hub_info.return_value = payload
+        result = await src.server.get_public_hub_info()
+        assert result == payload
+        mock_client.get_public_hub_info.assert_awaited_once()
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -256,6 +256,16 @@ class TestDeleteModelAccessGroup:
         mock_client.delete_model_access_group.assert_awaited_once_with("engineering")
 
 
+class TestListCredentials:
+    @pytest.mark.asyncio
+    async def test_passthrough(self, mock_client):
+        payload = [{"credential_name": "openai-prod", "credential_info": {}}]
+        mock_client.list_credentials.return_value = payload
+        result = await src.server.list_credentials("full")
+        assert result == payload
+        mock_client.list_credentials.assert_awaited_once()
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -144,6 +144,16 @@ class TestDeleteModel:
         mock_client.delete_model.assert_awaited_once_with("abc-123")
 
 
+class TestListPublicModels:
+    @pytest.mark.asyncio
+    async def test_passthrough_unfiltered(self, mock_client):
+        payload = [{"model_group": "gpt-4o", "providers": ["openai"]}]
+        mock_client.list_public_models.return_value = payload
+        result = await src.server.list_public_models("full")
+        assert result == payload
+        mock_client.list_public_models.assert_awaited_once()
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -341,6 +341,25 @@ class TestDeleteCredential:
         mock_client.delete_credential.assert_awaited_once_with("openai-prod")
 
 
+class TestListKeys:
+    @pytest.mark.asyncio
+    async def test_no_filters(self, mock_client):
+        mock_client.list_keys.return_value = {"keys": [], "total_count": 0}
+        result = await src.server.list_keys()
+        assert result == {"keys": [], "total_count": 0}
+        mock_client.list_keys.assert_awaited_once_with(
+            None, None, None, None, None, None, None, None, None, None
+        )
+
+    @pytest.mark.asyncio
+    async def test_filter_by_team(self, mock_client):
+        mock_client.list_keys.return_value = {"keys": [{"key_name": "sk-x"}]}
+        await src.server.list_keys(team_id="t-1", page=2)
+        mock_client.list_keys.assert_awaited_once_with(
+            2, None, None, "t-1", None, None, None, None, None, None
+        )
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -429,6 +429,24 @@ class TestGenerateServiceAccountKey:
         )
 
 
+class TestUpdateKey:
+    @pytest.mark.asyncio
+    async def test_minimal(self, mock_client):
+        mock_client.update_key.return_value = {"key": "sk-x"}
+        await src.server.update_key("sk-x", max_budget=50.0)
+        mock_client.update_key.assert_awaited_once_with(
+            "sk-x", None, None, None, 50.0, None, None, None, None, None, None, None
+        )
+
+    @pytest.mark.asyncio
+    async def test_extras(self, mock_client):
+        mock_client.update_key.return_value = {"key": "sk-x"}
+        await src.server.update_key("sk-x", extras={"max_parallel_requests": 8})
+        call = mock_client.update_key.await_args
+        assert call.args[0] == "sk-x"
+        assert call.args[11] == {"max_parallel_requests": 8}
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -333,6 +333,14 @@ class TestUpdateCredential:
         )
 
 
+class TestDeleteCredential:
+    @pytest.mark.asyncio
+    async def test_passes_credential_name(self, mock_client):
+        mock_client.delete_credential.return_value = {"deleted": True}
+        await src.server.delete_credential("openai-prod")
+        mock_client.delete_credential.assert_awaited_once_with("openai-prod")
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -81,6 +81,22 @@ class TestGetModel:
         assert result == {"id": "gpt-4o"}
 
 
+class TestGetModelInfo:
+    @pytest.mark.asyncio
+    async def test_passthrough_no_filter(self, mock_client):
+        payload = {"data": [{"model_name": "gpt-4o", "litellm_params": {"model": "openai/gpt-4o"}}]}
+        mock_client.get_model_info.return_value = payload
+        result = await src.server.get_model_info()
+        assert result == payload
+        mock_client.get_model_info.assert_awaited_once_with(None)
+
+    @pytest.mark.asyncio
+    async def test_passes_litellm_model_id(self, mock_client):
+        mock_client.get_model_info.return_value = {"data": []}
+        await src.server.get_model_info("abc-123")
+        mock_client.get_model_info.assert_awaited_once_with("abc-123")
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -164,6 +164,16 @@ class TestGetPublicHubInfo:
         mock_client.get_public_hub_info.assert_awaited_once()
 
 
+class TestGetModelCostMap:
+    @pytest.mark.asyncio
+    async def test_passthrough(self, mock_client):
+        payload = {"gpt-4o": {"input_cost_per_token": 1e-6}}
+        mock_client.get_model_cost_map.return_value = payload
+        result = await src.server.get_model_cost_map()
+        assert result == payload
+        mock_client.get_model_cost_map.assert_awaited_once()
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -368,6 +368,20 @@ class TestListKeyAliases:
         mock_client.list_key_aliases.assert_awaited_once_with(None, None, "prod", None)
 
 
+class TestGetKeyInfo:
+    @pytest.mark.asyncio
+    async def test_no_key(self, mock_client):
+        mock_client.get_key_info.return_value = {"key_name": "sk-x", "spend": 0}
+        await src.server.get_key_info()
+        mock_client.get_key_info.assert_awaited_once_with(None)
+
+    @pytest.mark.asyncio
+    async def test_with_key(self, mock_client):
+        mock_client.get_key_info.return_value = {"key_name": "sk-x"}
+        await src.server.get_key_info(key="sk-x", verbosity="full")
+        mock_client.get_key_info.assert_awaited_once_with("sk-x")
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -360,6 +360,14 @@ class TestListKeys:
         )
 
 
+class TestListKeyAliases:
+    @pytest.mark.asyncio
+    async def test_search_filter(self, mock_client):
+        mock_client.list_key_aliases.return_value = {"data": []}
+        await src.server.list_key_aliases(search="prod")
+        mock_client.list_key_aliases.assert_awaited_once_with(None, None, "prod", None)
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -278,6 +278,18 @@ class TestGetCredential:
         mock_client.get_credential.assert_awaited_once_with("openai-prod")
 
 
+class TestGetCredentialByModel:
+    @pytest.mark.asyncio
+    async def test_passes_model_id(self, mock_client):
+        mock_client.get_credential_by_model.return_value = {
+            "credential_name": "openai-prod",
+            "credential_info": {},
+        }
+        result = await src.server.get_credential_by_model("abc-123", "full")
+        assert result["credential_name"] == "openai-prod"
+        mock_client.get_credential_by_model.assert_awaited_once_with("abc-123")
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -179,9 +179,7 @@ class TestMakeModelGroupPublic:
     async def test_passes_model_groups(self, mock_client):
         mock_client.make_model_group_public.return_value = {"ok": True}
         await src.server.make_model_group_public(["gpt-4o", "claude-opus-4-7"])
-        mock_client.make_model_group_public.assert_awaited_once_with(
-            ["gpt-4o", "claude-opus-4-7"]
-        )
+        mock_client.make_model_group_public.assert_awaited_once_with(["gpt-4o", "claude-opus-4-7"])
 
 
 class TestUpdateModelHubLinks:
@@ -189,9 +187,7 @@ class TestUpdateModelHubLinks:
     async def test_passes_links(self, mock_client):
         mock_client.update_model_hub_links.return_value = {"ok": True}
         await src.server.update_model_hub_links({"Docs": "https://example.com"})
-        mock_client.update_model_hub_links.assert_awaited_once_with(
-            {"Docs": "https://example.com"}
-        )
+        mock_client.update_model_hub_links.assert_awaited_once_with({"Docs": "https://example.com"})
 
 
 class TestListModelAccessGroups:
@@ -221,9 +217,7 @@ class TestCreateModelAccessGroup:
     async def test_minimum_required(self, mock_client):
         mock_client.create_model_access_group.return_value = {"ok": True}
         await src.server.create_model_access_group("engineering")
-        mock_client.create_model_access_group.assert_awaited_once_with(
-            "engineering", None, None
-        )
+        mock_client.create_model_access_group.assert_awaited_once_with("engineering", None, None)
 
     @pytest.mark.asyncio
     async def test_with_members(self, mock_client):
@@ -240,9 +234,7 @@ class TestUpdateModelAccessGroup:
     @pytest.mark.asyncio
     async def test_replaces_models(self, mock_client):
         mock_client.update_model_access_group.return_value = {"ok": True}
-        await src.server.update_model_access_group(
-            "engineering", model_names=["claude-opus-4-7"]
-        )
+        await src.server.update_model_access_group("engineering", model_names=["claude-opus-4-7"])
         mock_client.update_model_access_group.assert_awaited_once_with(
             "engineering", ["claude-opus-4-7"], None
         )
@@ -400,8 +392,19 @@ class TestGenerateKey:
             team_id="t-1",
         )
         mock_client.generate_key.assert_awaited_once_with(
-            "prod-bot", "30d", ["gpt-4o"], 10.0, None,
-            None, "t-1", None, None, None, None, None, None,
+            "prod-bot",
+            "30d",
+            ["gpt-4o"],
+            10.0,
+            None,
+            None,
+            "t-1",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
         )
 
     @pytest.mark.asyncio
@@ -424,8 +427,19 @@ class TestGenerateServiceAccountKey:
             key_alias="ci-bot", duration="365d", team_id="t-1"
         )
         mock_client.generate_service_account_key.assert_awaited_once_with(
-            "ci-bot", "365d", None, None, None,
-            None, "t-1", None, None, None, None, None, None,
+            "ci-bot",
+            "365d",
+            None,
+            None,
+            None,
+            None,
+            "t-1",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
         )
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -174,6 +174,16 @@ class TestGetModelCostMap:
         mock_client.get_model_cost_map.assert_awaited_once()
 
 
+class TestMakeModelGroupPublic:
+    @pytest.mark.asyncio
+    async def test_passes_model_groups(self, mock_client):
+        mock_client.make_model_group_public.return_value = {"ok": True}
+        await src.server.make_model_group_public(["gpt-4o", "claude-opus-4-7"])
+        mock_client.make_model_group_public.assert_awaited_once_with(
+            ["gpt-4o", "claude-opus-4-7"]
+        )
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -477,6 +477,20 @@ class TestSetKeyBlocked:
         mock_client.set_key_blocked.assert_awaited_once_with("sk-x", False)
 
 
+class TestDeleteKeys:
+    @pytest.mark.asyncio
+    async def test_by_keys(self, mock_client):
+        mock_client.delete_keys.return_value = {"deleted": 2}
+        await src.server.delete_keys(keys=["sk-1", "sk-2"])
+        mock_client.delete_keys.assert_awaited_once_with(["sk-1", "sk-2"], None)
+
+    @pytest.mark.asyncio
+    async def test_by_aliases(self, mock_client):
+        mock_client.delete_keys.return_value = {"deleted": 1}
+        await src.server.delete_keys(key_aliases=["prod-bot"])
+        mock_client.delete_keys.assert_awaited_once_with(None, ["prod-bot"])
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -216,6 +216,26 @@ class TestGetModelAccessGroup:
         mock_client.get_model_access_group.assert_awaited_once_with("engineering")
 
 
+class TestCreateModelAccessGroup:
+    @pytest.mark.asyncio
+    async def test_minimum_required(self, mock_client):
+        mock_client.create_model_access_group.return_value = {"ok": True}
+        await src.server.create_model_access_group("engineering")
+        mock_client.create_model_access_group.assert_awaited_once_with(
+            "engineering", None, None
+        )
+
+    @pytest.mark.asyncio
+    async def test_with_members(self, mock_client):
+        mock_client.create_model_access_group.return_value = {"ok": True}
+        await src.server.create_model_access_group(
+            "engineering", model_names=["gpt-4o"], model_ids=["abc-123"]
+        )
+        mock_client.create_model_access_group.assert_awaited_once_with(
+            "engineering", ["gpt-4o"], ["abc-123"]
+        )
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -505,6 +505,15 @@ class TestResetKeySpend:
         mock_client.reset_key_spend.assert_awaited_once_with("sk-x", 5.5)
 
 
+class TestKeyHealth:
+    @pytest.mark.asyncio
+    async def test_no_args(self, mock_client):
+        mock_client.key_health.return_value = {"status": "healthy"}
+        result = await src.server.key_health()
+        assert result == {"status": "healthy"}
+        mock_client.key_health.assert_awaited_once_with()
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -317,6 +317,22 @@ class TestCreateCredential:
         )
 
 
+class TestUpdateCredential:
+    @pytest.mark.asyncio
+    async def test_passes_full_body(self, mock_client):
+        mock_client.update_credential.return_value = {"ok": True}
+        await src.server.update_credential(
+            "openai-prod",
+            {"custom_llm_provider": "openai"},
+            {"api_key": "sk-y"},
+        )
+        mock_client.update_credential.assert_awaited_once_with(
+            "openai-prod",
+            {"custom_llm_provider": "openai"},
+            {"api_key": "sk-y"},
+        )
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -114,6 +114,27 @@ class TestAddModel:
         )
 
 
+class TestUpdateModel:
+    @pytest.mark.asyncio
+    async def test_only_passes_set_fields(self, mock_client):
+        mock_client.update_model.return_value = {"ok": True}
+        await src.server.update_model("abc-123", model_name="gpt-4o-mini")
+        mock_client.update_model.assert_awaited_once_with("abc-123", "gpt-4o-mini", None, None)
+
+    @pytest.mark.asyncio
+    async def test_passes_all_fields(self, mock_client):
+        mock_client.update_model.return_value = {"ok": True}
+        await src.server.update_model(
+            "abc-123",
+            model_name="x",
+            litellm_params={"model": "y"},
+            model_info={"id": "abc-123"},
+        )
+        mock_client.update_model.assert_awaited_once_with(
+            "abc-123", "x", {"model": "y"}, {"id": "abc-123"}
+        )
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -248,6 +248,14 @@ class TestUpdateModelAccessGroup:
         )
 
 
+class TestDeleteModelAccessGroup:
+    @pytest.mark.asyncio
+    async def test_passes_access_group(self, mock_client):
+        mock_client.delete_model_access_group.return_value = {"deleted": True}
+        await src.server.delete_model_access_group("engineering")
+        mock_client.delete_model_access_group.assert_awaited_once_with("engineering")
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -135,6 +135,15 @@ class TestUpdateModel:
         )
 
 
+class TestDeleteModel:
+    @pytest.mark.asyncio
+    async def test_passes_model_id(self, mock_client):
+        mock_client.delete_model.return_value = {"deleted": True}
+        result = await src.server.delete_model("abc-123")
+        assert result == {"deleted": True}
+        mock_client.delete_model.assert_awaited_once_with("abc-123")
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -204,6 +204,18 @@ class TestListModelAccessGroups:
         mock_client.list_model_access_groups.assert_awaited_once()
 
 
+class TestGetModelAccessGroup:
+    @pytest.mark.asyncio
+    async def test_passes_access_group(self, mock_client):
+        mock_client.get_model_access_group.return_value = {
+            "access_group": "engineering",
+            "models": ["gpt-4o"],
+        }
+        result = await src.server.get_model_access_group("engineering", "full")
+        assert result["access_group"] == "engineering"
+        mock_client.get_model_access_group.assert_awaited_once_with("engineering")
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -184,6 +184,16 @@ class TestMakeModelGroupPublic:
         )
 
 
+class TestUpdateModelHubLinks:
+    @pytest.mark.asyncio
+    async def test_passes_links(self, mock_client):
+        mock_client.update_model_hub_links.return_value = {"ok": True}
+        await src.server.update_model_hub_links({"Docs": "https://example.com"})
+        mock_client.update_model_hub_links.assert_awaited_once_with(
+            {"Docs": "https://example.com"}
+        )
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -194,6 +194,16 @@ class TestUpdateModelHubLinks:
         )
 
 
+class TestListModelAccessGroups:
+    @pytest.mark.asyncio
+    async def test_passthrough(self, mock_client):
+        payload = [{"access_group": "engineering", "models": ["gpt-4o"]}]
+        mock_client.list_model_access_groups.return_value = payload
+        result = await src.server.list_model_access_groups("full")
+        assert result == payload
+        mock_client.list_model_access_groups.assert_awaited_once()
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -416,6 +416,19 @@ class TestGenerateKey:
         assert call.args[12] == {"agent_id": "a-1", "max_parallel_requests": 4}
 
 
+class TestGenerateServiceAccountKey:
+    @pytest.mark.asyncio
+    async def test_passes_args(self, mock_client):
+        mock_client.generate_service_account_key.return_value = {"key": "sk-svc"}
+        await src.server.generate_service_account_key(
+            key_alias="ci-bot", duration="365d", team_id="t-1"
+        )
+        mock_client.generate_service_account_key.assert_awaited_once_with(
+            "ci-bot", "365d", None, None, None,
+            None, "t-1", None, None, None, None, None, None,
+        )
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -382,6 +382,40 @@ class TestGetKeyInfo:
         mock_client.get_key_info.assert_awaited_once_with("sk-x")
 
 
+class TestGenerateKey:
+    @pytest.mark.asyncio
+    async def test_minimal(self, mock_client):
+        mock_client.generate_key.return_value = {"key": "sk-123", "key_name": "auto"}
+        result = await src.server.generate_key()
+        assert result["key"] == "sk-123"
+
+    @pytest.mark.asyncio
+    async def test_common_args(self, mock_client):
+        mock_client.generate_key.return_value = {"key": "sk-x"}
+        await src.server.generate_key(
+            key_alias="prod-bot",
+            duration="30d",
+            models=["gpt-4o"],
+            max_budget=10.0,
+            team_id="t-1",
+        )
+        mock_client.generate_key.assert_awaited_once_with(
+            "prod-bot", "30d", ["gpt-4o"], 10.0, None,
+            None, "t-1", None, None, None, None, None, None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_extras_merged(self, mock_client):
+        mock_client.generate_key.return_value = {"key": "sk-x"}
+        await src.server.generate_key(
+            key_alias="x",
+            extras={"agent_id": "a-1", "max_parallel_requests": 4},
+        )
+        call = mock_client.generate_key.await_args
+        assert call.args[0] == "x"
+        assert call.args[12] == {"agent_id": "a-1", "max_parallel_requests": 4}
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -236,6 +236,18 @@ class TestCreateModelAccessGroup:
         )
 
 
+class TestUpdateModelAccessGroup:
+    @pytest.mark.asyncio
+    async def test_replaces_models(self, mock_client):
+        mock_client.update_model_access_group.return_value = {"ok": True}
+        await src.server.update_model_access_group(
+            "engineering", model_names=["claude-opus-4-7"]
+        )
+        mock_client.update_model_access_group.assert_awaited_once_with(
+            "engineering", ["claude-opus-4-7"], None
+        )
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client


### PR DESCRIPTION
## Summary

Implements [US #535](https://taiga.tetra-ai.fr/project/tetra/us/535) — the admin-tooling slice of the litellm-mcp build. Adds 32 tools across 5 resource families on top of the v1.0.0 foundation from US #534, plus RESPONSE_FIELDS shapes, a read-only live smoke script, README + CLAUDE.md updates.

- **36 conventional commits**, one per tool (`feat(tools): …`) plus 4 cross-cutting (filtering / docs / smoke / style). Stop/resume friendly per the per-tool task-granularity convention.
- **52 unit tests** (was 4) — every tool has request-shape + response-handling coverage via `AsyncMock(LiteLLMClient)`.
- **15/15 read-only smoke tools pass** against local LiteLLM v1.83.7-stable.

## Tools added

| Family | Count | Tools |
|---|---|---|
| Models | 5 | `get_model`, `get_model_info`, `add_model`, `update_model`, `delete_model` |
| Model Hub | 5 | `list_public_models`, `get_public_hub_info`, `get_model_cost_map`, `make_model_group_public`, `update_model_hub_links` |
| Model Access Groups | 5 | `list_model_access_groups`, `get_model_access_group`, `create_model_access_group`, `update_model_access_group`, `delete_model_access_group` |
| Credentials | 6 | `list_credentials`, `get_credential`, `get_credential_by_model`, `create_credential`, `update_credential`, `delete_credential` |
| Keys | 11 | `list_keys`, `list_key_aliases`, `get_key_info`, `generate_key`, `generate_service_account_key`, `update_key`, `regenerate_key`, `set_key_blocked(blocked: bool)`, `delete_keys`, `reset_key_spend`, `key_health` |

## Conventions

- **Two-layer wiring:** every tool = one `LiteLLMClient` method + one thin `@mcp.tool()` wrapper. Mergeable as a tiny PR; mockable in tests.
- **`extras: dict` long-tail pattern:** for `generate_key` / `generate_service_account_key` / `update_key` / `regenerate_key` (40+ optional upstream fields each), the wrapper exposes ~12 common fields as named args and merges the rest from `extras`. Documented in CLAUDE.md.
- **`set_key_blocked(blocked: bool)`** compresses `POST /key/block` and `POST /key/unblock` into a single tool with a routing flag — cuts surface area without losing capability.
- **RESPONSE_FIELDS shapes** added for `access_group`, `credential`, `key`, `public_hub`. `credential.standard` deliberately drops `credential_values` to avoid leaking secrets into agent transcripts (use `verbosity='full'` to inspect).

## Live smoke findings (local LiteLLM v1.83.7-stable)

`uv run python tests/smoke.py` — 15/15 read-only tools pass. Two real-world LiteLLM quirks to flag (wrappers are correct; upstream behavior is what it is):

- `GET /v1/models/{model_id}` only resolves router-registered models, not OpenAI passthrough ids returned by `GET /v1/models`. Smoke treats 404 from a passthrough id as expected.
- `GET /key/info` 404s for the master key because it isn't a row in `LiteLLM_VerificationToken`. Smoke skips when no virtual keys exist to probe.

## Out of scope (re-routed by 2026-04-27 Swagger review)

- Identity / spend / chat / embeddings → US #536a, #536b.
- Production deployment (compose + Bifrost + Ansible) → US #537.
- Governance / multi-modal / passthrough → US #538.
- MCP gateway → US #558.

## Test plan

- [x] `uv run pytest -v` — 52 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run python tests/smoke.py` — 15/15 against local proxy
- [ ] Formal review (this PR)
- [ ] semrel cuts `v1.1.0` on merge (36 `feat:` commits)