### PR TITLE
feat: 31 identity tools (users, customers, orgs, projects, unified access groups)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,15 +14,24 @@ MCP server for the LiteLLM proxy. Python 3.12, fastmcp (`mcp.server.fastmcp`), h
 ## Conventions
 
 - All read-shaped tools accept a `verbosity: str` argument (`minimal` / `standard` / `full`) and route through `_filter_response`. Write/admin tools generally don't filter (`update_model`, `add_model`, etc. return upstream as-is).
-- Add new resource shapes to `RESPONSE_FIELDS` in `src/server.py`. Current shapes: `model`, `access_group`, `credential`, `key`, `public_hub`. The `credential.standard` shape intentionally drops `credential_values` to avoid leaking secrets — use `full` to inspect.
+- Add new resource shapes to `RESPONSE_FIELDS` in `src/server.py`. Current shapes: `model`, `access_group`, `credential`, `key`, `public_hub`, `user`, `customer`, `organization`, `project`, `user_access_group`. The `credential.standard` shape intentionally drops `credential_values` to avoid leaking secrets — use `full` to inspect.
 - New endpoints go on `LiteLLMClient` first, then a thin `@mcp.tool()` wrapper in `server.py`.
-- For body schemas with many optional fields (`GenerateKeyRequest`, `UpdateKeyRequest`, `RegenerateKeyRequest`), expose ~12 common fields as named args and accept the long tail through an `extras: Optional[dict]` argument (merged into the body via `_build_key_body`).
+- For body schemas with many optional fields (`GenerateKeyRequest`, `UpdateKeyRequest`, `RegenerateKeyRequest`, `NewUserRequest`, `NewCustomerRequest`, `NewOrganizationRequest`, `NewProjectRequest`), expose ~12 common fields as named args and accept the long tail through an `extras: Optional[dict]` argument (merged into the body via `_build_body`/`_build_key_body`).
 - Keep transport agnostic: never call `print` / write to stdout in stdio mode.
 
-## Current scope (US #534 + #535)
+## Current scope (US #534 + #535 + #536)
 
 - **#534 (v1.0.0):** foundation, `list_models`.
-- **#535:** 32 admin tools — Models (5), Model Hub (5), Access Groups (5), Credentials (6), Keys (11). All wrapped with unit tests against `AsyncMock(LiteLLMClient)`.
+- **#535 (v1.1.0):** 32 admin tools — Models (5), Model Hub (5), Access Groups (5), Credentials (6), Keys (11). All wrapped with unit tests against `AsyncMock(LiteLLMClient)`.
+- **#536:** 31 identity tools — Internal Users (5), Customers (7), Organizations (9, incl. member CRUD), Projects (5), Unified User Access Groups (5). Same test/smoke conventions.
+
+### Upstream quirks
+
+- `GET /v1/models/{id}` only resolves router-registered ids; passthrough ids 404. Use `get_model_info` for admin lookups.
+- `GET /key/info` 404s on the master key (not stored in `LiteLLM_VerificationToken`). Probe a virtual key.
+- `PATCH /credentials/{name}` is a full replace despite the verb; `CredentialItem` requires all three body fields.
+- `GET /customer/daily/activity` and `GET /organization/daily/activity` require `start_date` and `end_date` despite the OpenAPI marking them optional — omit either and you get HTTP 400.
+- `PATCH /organization/update` has no documented request body in the OpenAPI spec; the wrapper sends an UpdateOrganization payload mirroring NewOrganizationRequest.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ MCP server for [LiteLLM](https://github.com/BerriAI/litellm) proxy administratio
 
 **Upstream API reference:** [LiteLLM proxy Swagger](https://litellm-api.up.railway.app/).
 
-Foundation (US #534) shipped `list_models`. Admin slice (US #535) adds 32 tools
+Foundation (US #534) shipped `list_models`. Admin slice (US #535) added 32 tools
 covering models, model hub, model access groups, credentials, and virtual keys.
-Subsequent slices add identity/teams/spend/execution (#536), governance and
+Identity slice (US #536) adds 31 tools covering internal users, customers,
+organizations (with member management), projects, and unified user access
+groups. Subsequent slices add spend/execution (#536b), governance and
 passthrough (#538), and the MCP-of-MCPs gateway (#558).
 
 ## Setup
@@ -133,6 +135,69 @@ All tools accept a `verbosity` arg (`minimal` / `standard` / `full`) where it ma
 `generate_key`, `generate_service_account_key`, `update_key`, and `regenerate_key`
 expose the most common ~12 fields as named args; pass any other upstream field
 via the `extras: dict` argument (merged into the request body).
+
+### Internal Users (5)
+
+| Tool | Endpoint |
+|------|----------|
+| `list_users` | `GET /user/list` |
+| `get_user_info` | `GET /user/info` |
+| `create_user` | `POST /user/new` |
+| `update_user` | `POST /user/update` |
+| `delete_user` | `POST /user/delete` |
+
+### Customers (7)
+
+| Tool | Endpoint |
+|------|----------|
+| `list_customers` | `GET /customer/list` |
+| `get_customer_info` | `GET /customer/info` |
+| `create_customer` | `POST /customer/new` |
+| `update_customer` | `POST /customer/update` |
+| `delete_customer` | `POST /customer/delete` |
+| `set_customer_blocked(blocked: bool)` | `POST /customer/block` ∣ `POST /customer/unblock` |
+| `get_customer_daily_activity` | `GET /customer/daily/activity` |
+
+### Organizations (9)
+
+| Tool | Endpoint |
+|------|----------|
+| `list_organizations` | `GET /organization/list` |
+| `get_organization_info` | `GET /organization/info` |
+| `create_organization` | `POST /organization/new` |
+| `update_organization` | `PATCH /organization/update` |
+| `delete_organization` | `DELETE /organization/delete` |
+| `add_org_member` | `POST /organization/member_add` |
+| `update_org_member` | `PATCH /organization/member_update` |
+| `delete_org_member` | `DELETE /organization/member_delete` |
+| `get_org_daily_activity` | `GET /organization/daily/activity` |
+
+### Projects (5)
+
+| Tool | Endpoint |
+|------|----------|
+| `list_projects` | `GET /project/list` |
+| `get_project_info` | `GET /project/info` |
+| `create_project` | `POST /project/new` |
+| `update_project` | `POST /project/update` |
+| `delete_project` | `DELETE /project/delete` |
+
+### Unified User Access Groups (5)
+
+| Tool | Endpoint |
+|------|----------|
+| `list_user_access_groups` | `GET /v1/unified_access_group` |
+| `get_user_access_group` | `GET /v1/unified_access_group/{id}` |
+| `create_user_access_group` | `POST /v1/unified_access_group` |
+| `update_user_access_group` | `PUT /v1/unified_access_group/{id}` |
+| `delete_user_access_group` | `DELETE /v1/unified_access_group/{id}` |
+
+Distinct from the model-access-groups family above — unified user access
+groups gate users/teams against models, MCP servers, and agents in one shape.
+`create_user`, `update_user`, `create_customer`, `update_customer`,
+`create_organization`, `update_organization`, `create_project`, and
+`update_project` accept an `extras: dict` argument for the long tail of
+upstream fields not surfaced as named args.
 
 ## Development
 

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -594,3 +594,654 @@ class LiteLLMClient:
         Returns connectivity / permission status for the bearer key. No body.
         """
         return await self._request("POST", "/key/health")
+
+    # ── Internal User operations ──
+
+    @staticmethod
+    def _build_body(common: dict[str, Any], extras: Optional[dict] = None) -> dict[str, Any]:
+        """Build a request body: drop None entries from common, merge extras."""
+        body = {k: v for k, v in common.items() if v is not None}
+        if extras:
+            body.update(extras)
+        return body
+
+    async def list_users(
+        self,
+        role: Optional[str] = None,
+        user_ids: Optional[str] = None,
+        sso_user_ids: Optional[str] = None,
+        user_email: Optional[str] = None,
+        team: Optional[str] = None,
+        page: Optional[int] = None,
+        page_size: Optional[int] = None,
+        sort_by: Optional[str] = None,
+        sort_order: Optional[str] = None,
+        organization_ids: Optional[str] = None,
+    ) -> dict:
+        """List internal LiteLLM users (`GET /user/list`).
+
+        All filters are optional. `user_ids`, `sso_user_ids`, `organization_ids`
+        are upstream-comma-separated strings (not arrays).
+        """
+        params = {
+            k: v
+            for k, v in {
+                "role": role,
+                "user_ids": user_ids,
+                "sso_user_ids": sso_user_ids,
+                "user_email": user_email,
+                "team": team,
+                "page": page,
+                "page_size": page_size,
+                "sort_by": sort_by,
+                "sort_order": sort_order,
+                "organization_ids": organization_ids,
+            }.items()
+            if v is not None
+        }
+        return await self._request("GET", "/user/list", params=params or None)
+
+    async def get_user_info(self, user_id: Optional[str] = None) -> dict:
+        """Get info about an internal user (`GET /user/info`).
+
+        If `user_id` is omitted, the upstream returns info about the caller.
+        """
+        params = {"user_id": user_id} if user_id else None
+        return await self._request("GET", "/user/info", params=params)
+
+    async def create_user(
+        self,
+        user_email: Optional[str] = None,
+        user_id: Optional[str] = None,
+        user_alias: Optional[str] = None,
+        user_role: Optional[str] = None,
+        teams: Optional[list[str]] = None,
+        organizations: Optional[list[str]] = None,
+        models: Optional[list[str]] = None,
+        max_budget: Optional[float] = None,
+        budget_duration: Optional[str] = None,
+        tpm_limit: Optional[int] = None,
+        rpm_limit: Optional[int] = None,
+        metadata: Optional[dict] = None,
+        guardrails: Optional[list[str]] = None,
+        blocked: Optional[bool] = None,
+        auto_create_key: Optional[bool] = None,
+        send_invite_email: Optional[bool] = None,
+        extras: Optional[dict] = None,
+    ) -> dict:
+        """Create an internal user (`POST /user/new`).
+
+        ~12 common NewUserRequest fields are surfaced as named args; pass any
+        other upstream field via `extras` (merged last into the body). All args
+        are optional — upstream defaults apply.
+        """
+        body = self._build_body(
+            {
+                "user_email": user_email,
+                "user_id": user_id,
+                "user_alias": user_alias,
+                "user_role": user_role,
+                "teams": teams,
+                "organizations": organizations,
+                "models": models,
+                "max_budget": max_budget,
+                "budget_duration": budget_duration,
+                "tpm_limit": tpm_limit,
+                "rpm_limit": rpm_limit,
+                "metadata": metadata,
+                "guardrails": guardrails,
+                "blocked": blocked,
+                "auto_create_key": auto_create_key,
+                "send_invite_email": send_invite_email,
+            },
+            extras,
+        )
+        return await self._request("POST", "/user/new", json=body)
+
+    async def update_user(
+        self,
+        user_id: str,
+        user_email: Optional[str] = None,
+        user_alias: Optional[str] = None,
+        user_role: Optional[str] = None,
+        password: Optional[str] = None,
+        models: Optional[list[str]] = None,
+        max_budget: Optional[float] = None,
+        budget_duration: Optional[str] = None,
+        tpm_limit: Optional[int] = None,
+        rpm_limit: Optional[int] = None,
+        metadata: Optional[dict] = None,
+        guardrails: Optional[list[str]] = None,
+        blocked: Optional[bool] = None,
+        extras: Optional[dict] = None,
+    ) -> dict:
+        """Update an internal user (`POST /user/update`).
+
+        Only `user_id` is required; other args are merged sparsely. Use
+        `extras` for less-common UpdateUserRequest fields.
+        """
+        body = self._build_body(
+            {
+                "user_id": user_id,
+                "user_email": user_email,
+                "user_alias": user_alias,
+                "user_role": user_role,
+                "password": password,
+                "models": models,
+                "max_budget": max_budget,
+                "budget_duration": budget_duration,
+                "tpm_limit": tpm_limit,
+                "rpm_limit": rpm_limit,
+                "metadata": metadata,
+                "guardrails": guardrails,
+                "blocked": blocked,
+            },
+            extras,
+        )
+        return await self._request("POST", "/user/update", json=body)
+
+    async def delete_user(self, user_ids: list[str]) -> dict:
+        """Batch-delete internal users (`POST /user/delete`).
+
+        Body is `{"user_ids": [...]}`. At least one id is required.
+        """
+        return await self._request("POST", "/user/delete", json={"user_ids": user_ids})
+
+    # ── Customer (end-user) operations ──
+
+    async def list_customers(self) -> Any:
+        """List end-user customers (`GET /customer/list`)."""
+        return await self._request("GET", "/customer/list")
+
+    async def get_customer_info(self, end_user_id: str) -> dict:
+        """Get a customer by end_user_id (`GET /customer/info`)."""
+        return await self._request("GET", "/customer/info", params={"end_user_id": end_user_id})
+
+    async def create_customer(
+        self,
+        user_id: str,
+        alias: Optional[str] = None,
+        max_budget: Optional[float] = None,
+        soft_budget: Optional[float] = None,
+        budget_id: Optional[str] = None,
+        budget_duration: Optional[str] = None,
+        tpm_limit: Optional[int] = None,
+        rpm_limit: Optional[int] = None,
+        max_parallel_requests: Optional[int] = None,
+        blocked: Optional[bool] = None,
+        allowed_model_region: Optional[str] = None,
+        default_model: Optional[str] = None,
+        extras: Optional[dict] = None,
+    ) -> dict:
+        """Create a customer (`POST /customer/new`).
+
+        `user_id` is required (the customer's stable end-user id). Other fields
+        are optional; pass uncommon NewCustomerRequest fields via `extras`.
+        """
+        body = self._build_body(
+            {
+                "user_id": user_id,
+                "alias": alias,
+                "max_budget": max_budget,
+                "soft_budget": soft_budget,
+                "budget_id": budget_id,
+                "budget_duration": budget_duration,
+                "tpm_limit": tpm_limit,
+                "rpm_limit": rpm_limit,
+                "max_parallel_requests": max_parallel_requests,
+                "blocked": blocked,
+                "allowed_model_region": allowed_model_region,
+                "default_model": default_model,
+            },
+            extras,
+        )
+        return await self._request("POST", "/customer/new", json=body)
+
+    async def update_customer(
+        self,
+        user_id: str,
+        alias: Optional[str] = None,
+        max_budget: Optional[float] = None,
+        budget_id: Optional[str] = None,
+        blocked: Optional[bool] = None,
+        allowed_model_region: Optional[str] = None,
+        default_model: Optional[str] = None,
+        extras: Optional[dict] = None,
+    ) -> dict:
+        """Update a customer (`POST /customer/update`).
+
+        `user_id` is required. UpdateCustomerRequest is intentionally narrower
+        than NewCustomerRequest upstream — pass less-common fields via `extras`.
+        """
+        body = self._build_body(
+            {
+                "user_id": user_id,
+                "alias": alias,
+                "max_budget": max_budget,
+                "budget_id": budget_id,
+                "blocked": blocked,
+                "allowed_model_region": allowed_model_region,
+                "default_model": default_model,
+            },
+            extras,
+        )
+        return await self._request("POST", "/customer/update", json=body)
+
+    async def delete_customer(self, user_ids: list[str]) -> dict:
+        """Batch-delete customers (`POST /customer/delete`).
+
+        Body is `{"user_ids": [...]}`.
+        """
+        return await self._request("POST", "/customer/delete", json={"user_ids": user_ids})
+
+    async def set_customer_blocked(self, user_ids: list[str], blocked: bool) -> dict:
+        """Block or unblock customers.
+
+        Routes to `POST /customer/block` when `blocked=True`, else
+        `POST /customer/unblock`. Body in both cases is `{"user_ids": [...]}`.
+        """
+        path = "/customer/block" if blocked else "/customer/unblock"
+        return await self._request("POST", path, json={"user_ids": user_ids})
+
+    async def get_customer_daily_activity(
+        self,
+        end_user_ids: Optional[str] = None,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        model: Optional[str] = None,
+        api_key: Optional[str] = None,
+        page: Optional[int] = None,
+        page_size: Optional[int] = None,
+        exclude_end_user_ids: Optional[str] = None,
+    ) -> dict:
+        """Per-customer daily activity (`GET /customer/daily/activity`).
+
+        `start_date` and `end_date` (ISO `YYYY-MM-DD`) are required upstream —
+        omitting either returns HTTP 400, despite the OpenAPI spec marking
+        them optional. `end_user_ids` and `exclude_end_user_ids` are
+        upstream-comma-separated strings (not arrays).
+        """
+        params = {
+            k: v
+            for k, v in {
+                "end_user_ids": end_user_ids,
+                "start_date": start_date,
+                "end_date": end_date,
+                "model": model,
+                "api_key": api_key,
+                "page": page,
+                "page_size": page_size,
+                "exclude_end_user_ids": exclude_end_user_ids,
+            }.items()
+            if v is not None
+        }
+        return await self._request("GET", "/customer/daily/activity", params=params or None)
+
+    # ── Organization operations ──
+
+    async def list_organizations(
+        self,
+        org_id: Optional[str] = None,
+        org_alias: Optional[str] = None,
+    ) -> Any:
+        """List organizations (`GET /organization/list`)."""
+        params = {
+            k: v for k, v in {"org_id": org_id, "org_alias": org_alias}.items() if v is not None
+        }
+        return await self._request("GET", "/organization/list", params=params or None)
+
+    async def get_organization_info(self, organization_id: str) -> dict:
+        """Get a single organization by id (`GET /organization/info`)."""
+        return await self._request(
+            "GET", "/organization/info", params={"organization_id": organization_id}
+        )
+
+    async def create_organization(
+        self,
+        organization_alias: str,
+        organization_id: Optional[str] = None,
+        models: Optional[list[str]] = None,
+        max_budget: Optional[float] = None,
+        soft_budget: Optional[float] = None,
+        budget_id: Optional[str] = None,
+        budget_duration: Optional[str] = None,
+        tpm_limit: Optional[int] = None,
+        rpm_limit: Optional[int] = None,
+        max_parallel_requests: Optional[int] = None,
+        metadata: Optional[dict] = None,
+        extras: Optional[dict] = None,
+    ) -> dict:
+        """Create an organization (`POST /organization/new`).
+
+        `organization_alias` is the only required field. Other common
+        NewOrganizationRequest fields are surfaced as named args; pass less
+        common ones via `extras`.
+        """
+        body = self._build_body(
+            {
+                "organization_alias": organization_alias,
+                "organization_id": organization_id,
+                "models": models,
+                "max_budget": max_budget,
+                "soft_budget": soft_budget,
+                "budget_id": budget_id,
+                "budget_duration": budget_duration,
+                "tpm_limit": tpm_limit,
+                "rpm_limit": rpm_limit,
+                "max_parallel_requests": max_parallel_requests,
+                "metadata": metadata,
+            },
+            extras,
+        )
+        return await self._request("POST", "/organization/new", json=body)
+
+    async def update_organization(
+        self,
+        organization_id: str,
+        organization_alias: Optional[str] = None,
+        models: Optional[list[str]] = None,
+        max_budget: Optional[float] = None,
+        budget_duration: Optional[str] = None,
+        tpm_limit: Optional[int] = None,
+        rpm_limit: Optional[int] = None,
+        metadata: Optional[dict] = None,
+        extras: Optional[dict] = None,
+    ) -> dict:
+        """Patch an organization (`PATCH /organization/update`).
+
+        Upstream OpenAPI omits the request body schema for this endpoint, but
+        the implementation accepts an UpdateOrganization payload mirroring
+        NewOrganizationRequest minus the alias requirement. `organization_id`
+        is required in the body to identify the row; other fields are merged
+        sparsely. Use `extras` for any field not surfaced here.
+        """
+        body = self._build_body(
+            {
+                "organization_id": organization_id,
+                "organization_alias": organization_alias,
+                "models": models,
+                "max_budget": max_budget,
+                "budget_duration": budget_duration,
+                "tpm_limit": tpm_limit,
+                "rpm_limit": rpm_limit,
+                "metadata": metadata,
+            },
+            extras,
+        )
+        return await self._request("PATCH", "/organization/update", json=body)
+
+    async def delete_organization(self, organization_ids: list[str]) -> dict:
+        """Batch-delete organizations (`DELETE /organization/delete`).
+
+        Note: this is a `DELETE` with a JSON body — `{"organization_ids": [...]}`.
+        """
+        return await self._request(
+            "DELETE", "/organization/delete", json={"organization_ids": organization_ids}
+        )
+
+    async def add_org_member(
+        self,
+        organization_id: str,
+        member: dict,
+        max_budget_in_organization: Optional[float] = None,
+    ) -> dict:
+        """Add a member to an organization (`POST /organization/member_add`).
+
+        `member` is the upstream Member shape — at minimum
+        `{"user_id" or "user_email": ..., "role": ...}`.
+        """
+        body: dict[str, Any] = {"organization_id": organization_id, "member": member}
+        if max_budget_in_organization is not None:
+            body["max_budget_in_organization"] = max_budget_in_organization
+        return await self._request("POST", "/organization/member_add", json=body)
+
+    async def update_org_member(
+        self,
+        organization_id: str,
+        user_id: Optional[str] = None,
+        user_email: Optional[str] = None,
+        role: Optional[str] = None,
+        max_budget_in_organization: Optional[float] = None,
+    ) -> dict:
+        """Update an org member (`PATCH /organization/member_update`).
+
+        Identify the member by `user_id` or `user_email`. Only the fields you
+        pass are sent.
+        """
+        body = self._build_body(
+            {
+                "organization_id": organization_id,
+                "user_id": user_id,
+                "user_email": user_email,
+                "role": role,
+                "max_budget_in_organization": max_budget_in_organization,
+            }
+        )
+        return await self._request("PATCH", "/organization/member_update", json=body)
+
+    async def delete_org_member(
+        self,
+        organization_id: str,
+        user_id: Optional[str] = None,
+        user_email: Optional[str] = None,
+    ) -> dict:
+        """Remove an org member (`DELETE /organization/member_delete`).
+
+        Identify the member by `user_id` or `user_email`. DELETE with JSON
+        body — supported by the upstream.
+        """
+        body = self._build_body(
+            {"organization_id": organization_id, "user_id": user_id, "user_email": user_email}
+        )
+        return await self._request("DELETE", "/organization/member_delete", json=body)
+
+    async def get_org_daily_activity(
+        self,
+        organization_ids: Optional[str] = None,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        model: Optional[str] = None,
+        api_key: Optional[str] = None,
+        page: Optional[int] = None,
+        page_size: Optional[int] = None,
+        exclude_organization_ids: Optional[str] = None,
+    ) -> dict:
+        """Per-org daily activity (`GET /organization/daily/activity`).
+
+        `start_date` and `end_date` (ISO `YYYY-MM-DD`) are required upstream —
+        omitting either returns HTTP 400, despite the OpenAPI spec marking
+        them optional. `organization_ids` and `exclude_organization_ids` are
+        upstream-comma-separated strings (not arrays).
+        """
+        params = {
+            k: v
+            for k, v in {
+                "organization_ids": organization_ids,
+                "start_date": start_date,
+                "end_date": end_date,
+                "model": model,
+                "api_key": api_key,
+                "page": page,
+                "page_size": page_size,
+                "exclude_organization_ids": exclude_organization_ids,
+            }.items()
+            if v is not None
+        }
+        return await self._request("GET", "/organization/daily/activity", params=params or None)
+
+    # ── Project operations ──
+
+    async def list_projects(self) -> Any:
+        """List projects (`GET /project/list`)."""
+        return await self._request("GET", "/project/list")
+
+    async def get_project_info(self, project_id: str) -> dict:
+        """Get a project by id (`GET /project/info`)."""
+        return await self._request("GET", "/project/info", params={"project_id": project_id})
+
+    async def create_project(
+        self,
+        team_id: str,
+        project_id: Optional[str] = None,
+        project_alias: Optional[str] = None,
+        description: Optional[str] = None,
+        models: Optional[list[str]] = None,
+        max_budget: Optional[float] = None,
+        soft_budget: Optional[float] = None,
+        budget_duration: Optional[str] = None,
+        tpm_limit: Optional[int] = None,
+        rpm_limit: Optional[int] = None,
+        tags: Optional[list[str]] = None,
+        metadata: Optional[dict] = None,
+        guardrails: Optional[list[str]] = None,
+        blocked: Optional[bool] = None,
+        extras: Optional[dict] = None,
+    ) -> dict:
+        """Create a project (`POST /project/new`).
+
+        `team_id` is required (projects belong to teams). Other fields are
+        optional; pass less-common NewProjectRequest fields via `extras`.
+        """
+        body = self._build_body(
+            {
+                "team_id": team_id,
+                "project_id": project_id,
+                "project_alias": project_alias,
+                "description": description,
+                "models": models,
+                "max_budget": max_budget,
+                "soft_budget": soft_budget,
+                "budget_duration": budget_duration,
+                "tpm_limit": tpm_limit,
+                "rpm_limit": rpm_limit,
+                "tags": tags,
+                "metadata": metadata,
+                "guardrails": guardrails,
+                "blocked": blocked,
+            },
+            extras,
+        )
+        return await self._request("POST", "/project/new", json=body)
+
+    async def update_project(
+        self,
+        project_id: str,
+        project_alias: Optional[str] = None,
+        description: Optional[str] = None,
+        models: Optional[list[str]] = None,
+        max_budget: Optional[float] = None,
+        budget_duration: Optional[str] = None,
+        tpm_limit: Optional[int] = None,
+        rpm_limit: Optional[int] = None,
+        tags: Optional[list[str]] = None,
+        metadata: Optional[dict] = None,
+        guardrails: Optional[list[str]] = None,
+        blocked: Optional[bool] = None,
+        extras: Optional[dict] = None,
+    ) -> dict:
+        """Update a project (`POST /project/update`).
+
+        Only `project_id` is required; other fields are merged sparsely.
+        """
+        body = self._build_body(
+            {
+                "project_id": project_id,
+                "project_alias": project_alias,
+                "description": description,
+                "models": models,
+                "max_budget": max_budget,
+                "budget_duration": budget_duration,
+                "tpm_limit": tpm_limit,
+                "rpm_limit": rpm_limit,
+                "tags": tags,
+                "metadata": metadata,
+                "guardrails": guardrails,
+                "blocked": blocked,
+            },
+            extras,
+        )
+        return await self._request("POST", "/project/update", json=body)
+
+    async def delete_project(self, project_ids: list[str]) -> dict:
+        """Batch-delete projects (`DELETE /project/delete`).
+
+        DELETE with JSON body — `{"project_ids": [...]}`.
+        """
+        return await self._request("DELETE", "/project/delete", json={"project_ids": project_ids})
+
+    # ── Unified User Access Group operations ──
+    #
+    # Wraps `/v1/unified_access_group/*`. Distinct from model-access-groups
+    # (`/access_group/*`, in #535) — unified access groups gate users/teams
+    # against models, MCP servers, and agents in one shape.
+
+    async def list_user_access_groups(self) -> Any:
+        """List unified user access groups (`GET /v1/unified_access_group`)."""
+        return await self._request("GET", "/v1/unified_access_group")
+
+    async def get_user_access_group(self, access_group_id: str) -> dict:
+        """Get a unified access group by id (`GET /v1/unified_access_group/{id}`)."""
+        return await self._request("GET", f"/v1/unified_access_group/{access_group_id}")
+
+    async def create_user_access_group(
+        self,
+        access_group_name: str,
+        description: Optional[str] = None,
+        access_model_names: Optional[list[str]] = None,
+        access_mcp_server_ids: Optional[list[str]] = None,
+        access_agent_ids: Optional[list[str]] = None,
+        assigned_team_ids: Optional[list[str]] = None,
+        assigned_key_ids: Optional[list[str]] = None,
+    ) -> dict:
+        """Create a unified user access group (`POST /v1/unified_access_group`).
+
+        `access_group_name` is required; the access_* and assigned_* lists are
+        all optional and can be added later via update.
+        """
+        body = self._build_body(
+            {
+                "access_group_name": access_group_name,
+                "description": description,
+                "access_model_names": access_model_names,
+                "access_mcp_server_ids": access_mcp_server_ids,
+                "access_agent_ids": access_agent_ids,
+                "assigned_team_ids": assigned_team_ids,
+                "assigned_key_ids": assigned_key_ids,
+            }
+        )
+        return await self._request("POST", "/v1/unified_access_group", json=body)
+
+    async def update_user_access_group(
+        self,
+        access_group_id: str,
+        access_group_name: Optional[str] = None,
+        description: Optional[str] = None,
+        access_model_names: Optional[list[str]] = None,
+        access_mcp_server_ids: Optional[list[str]] = None,
+        access_agent_ids: Optional[list[str]] = None,
+        assigned_team_ids: Optional[list[str]] = None,
+        assigned_key_ids: Optional[list[str]] = None,
+    ) -> dict:
+        """Update a unified user access group (`PUT /v1/unified_access_group/{id}`).
+
+        All fields are optional; only the ones passed are sent. Note: this is
+        `PUT`, not `PATCH`, but the upstream merges sparsely.
+        """
+        body = self._build_body(
+            {
+                "access_group_name": access_group_name,
+                "description": description,
+                "access_model_names": access_model_names,
+                "access_mcp_server_ids": access_mcp_server_ids,
+                "access_agent_ids": access_agent_ids,
+                "assigned_team_ids": assigned_team_ids,
+                "assigned_key_ids": assigned_key_ids,
+            }
+        )
+        return await self._request(
+            "PUT", f"/v1/unified_access_group/{access_group_id}", json=body or None
+        )
+
+    async def delete_user_access_group(self, access_group_id: str) -> dict:
+        """Delete a unified user access group (`DELETE /v1/unified_access_group/{id}`)."""
+        return await self._request("DELETE", f"/v1/unified_access_group/{access_group_id}")

--- a/src/server.py
+++ b/src/server.py
@@ -58,6 +58,78 @@ RESPONSE_FIELDS: dict[str, dict[str, Optional[list[str]]]] = {
         "standard": ["model_group", "providers", "max_input_tokens", "max_output_tokens"],
         "full": None,
     },
+    "user": {
+        "minimal": ["user_id", "user_email"],
+        "standard": [
+            "user_id",
+            "user_email",
+            "user_alias",
+            "user_role",
+            "teams",
+            "organizations",
+            "models",
+            "max_budget",
+            "spend",
+            "blocked",
+        ],
+        "full": None,
+    },
+    "customer": {
+        "minimal": ["user_id", "alias"],
+        "standard": [
+            "user_id",
+            "alias",
+            "max_budget",
+            "spend",
+            "blocked",
+            "default_model",
+            "allowed_model_region",
+            "budget_duration",
+        ],
+        "full": None,
+    },
+    "organization": {
+        "minimal": ["organization_id", "organization_alias"],
+        "standard": [
+            "organization_id",
+            "organization_alias",
+            "models",
+            "max_budget",
+            "spend",
+            "budget_duration",
+            "metadata",
+        ],
+        "full": None,
+    },
+    "project": {
+        "minimal": ["project_id", "project_alias"],
+        "standard": [
+            "project_id",
+            "project_alias",
+            "team_id",
+            "description",
+            "models",
+            "max_budget",
+            "spend",
+            "blocked",
+            "tags",
+        ],
+        "full": None,
+    },
+    "user_access_group": {
+        "minimal": ["access_group_id", "access_group_name"],
+        "standard": [
+            "access_group_id",
+            "access_group_name",
+            "description",
+            "access_model_names",
+            "access_mcp_server_ids",
+            "access_agent_ids",
+            "assigned_team_ids",
+            "assigned_key_ids",
+        ],
+        "full": None,
+    },
 }
 
 VALID_VERBOSITY_LEVELS = {"minimal", "standard", "full"}
@@ -670,6 +742,693 @@ async def get_model_info(litellm_model_id: Optional[str] = None) -> dict:
             single deployment.
     """
     return await get_client().get_model_info(litellm_model_id)
+
+
+# ── Internal User tools ──
+
+
+@mcp.tool()
+async def list_users(
+    role: Optional[str] = None,
+    user_ids: Optional[str] = None,
+    sso_user_ids: Optional[str] = None,
+    user_email: Optional[str] = None,
+    team: Optional[str] = None,
+    page: Optional[int] = None,
+    page_size: Optional[int] = None,
+    sort_by: Optional[str] = None,
+    sort_order: Optional[str] = None,
+    organization_ids: Optional[str] = None,
+    verbosity: str = "standard",
+) -> dict:
+    """List internal LiteLLM users (`GET /user/list`).
+
+    `user_ids`, `sso_user_ids`, `organization_ids` are upstream-comma-separated
+    strings (not arrays). Verbosity filters the items inside the `users` array
+    if present.
+
+    Args:
+        verbosity: 'minimal' / 'standard' / 'full'.
+    """
+    payload = await get_client().list_users(
+        role,
+        user_ids,
+        sso_user_ids,
+        user_email,
+        team,
+        page,
+        page_size,
+        sort_by,
+        sort_order,
+        organization_ids,
+    )
+    if isinstance(payload, dict) and "users" in payload:
+        payload = dict(payload)
+        payload["users"] = _filter_response(payload["users"], "user", verbosity)
+    elif isinstance(payload, list):
+        payload = _filter_response(payload, "user", verbosity)
+    return payload
+
+
+@mcp.tool()
+async def get_user_info(user_id: Optional[str] = None, verbosity: str = "standard") -> dict:
+    """Get info about an internal user (`GET /user/info`).
+
+    Args:
+        user_id: Optional user id. If omitted, returns info about the caller.
+        verbosity: 'minimal' / 'standard' / 'full'.
+    """
+    payload = await get_client().get_user_info(user_id)
+    return _filter_response(payload, "user", verbosity)
+
+
+@mcp.tool()
+async def create_user(
+    user_email: Optional[str] = None,
+    user_id: Optional[str] = None,
+    user_alias: Optional[str] = None,
+    user_role: Optional[str] = None,
+    teams: Optional[list[str]] = None,
+    organizations: Optional[list[str]] = None,
+    models: Optional[list[str]] = None,
+    max_budget: Optional[float] = None,
+    budget_duration: Optional[str] = None,
+    tpm_limit: Optional[int] = None,
+    rpm_limit: Optional[int] = None,
+    metadata: Optional[dict] = None,
+    guardrails: Optional[list[str]] = None,
+    blocked: Optional[bool] = None,
+    auto_create_key: Optional[bool] = None,
+    send_invite_email: Optional[bool] = None,
+    extras: Optional[dict] = None,
+) -> dict:
+    """Create an internal user (`POST /user/new`).
+
+    All fields are optional. Use `extras` for any NewUserRequest field not
+    surfaced as a named arg (~20 less common fields like `permissions`,
+    `model_max_budget`, `aliases`, `object_permission`).
+    """
+    return await get_client().create_user(
+        user_email,
+        user_id,
+        user_alias,
+        user_role,
+        teams,
+        organizations,
+        models,
+        max_budget,
+        budget_duration,
+        tpm_limit,
+        rpm_limit,
+        metadata,
+        guardrails,
+        blocked,
+        auto_create_key,
+        send_invite_email,
+        extras,
+    )
+
+
+@mcp.tool()
+async def update_user(
+    user_id: str,
+    user_email: Optional[str] = None,
+    user_alias: Optional[str] = None,
+    user_role: Optional[str] = None,
+    password: Optional[str] = None,
+    models: Optional[list[str]] = None,
+    max_budget: Optional[float] = None,
+    budget_duration: Optional[str] = None,
+    tpm_limit: Optional[int] = None,
+    rpm_limit: Optional[int] = None,
+    metadata: Optional[dict] = None,
+    guardrails: Optional[list[str]] = None,
+    blocked: Optional[bool] = None,
+    extras: Optional[dict] = None,
+) -> dict:
+    """Update an internal user (`POST /user/update`).
+
+    Only `user_id` is required. Use `extras` for less-common UpdateUserRequest
+    fields (e.g. `permissions`, `aliases`, `object_permission`).
+    """
+    return await get_client().update_user(
+        user_id,
+        user_email,
+        user_alias,
+        user_role,
+        password,
+        models,
+        max_budget,
+        budget_duration,
+        tpm_limit,
+        rpm_limit,
+        metadata,
+        guardrails,
+        blocked,
+        extras,
+    )
+
+
+@mcp.tool()
+async def delete_user(user_ids: list[str]) -> dict:
+    """Batch-delete internal users (`POST /user/delete`).
+
+    Args:
+        user_ids: list of user ids to delete (at least one).
+    """
+    return await get_client().delete_user(user_ids)
+
+
+# ── Customer tools ──
+
+
+@mcp.tool()
+async def list_customers(verbosity: str = "standard") -> Any:
+    """List end-user customers (`GET /customer/list`).
+
+    Args:
+        verbosity: 'minimal' / 'standard' / 'full'.
+    """
+    payload = await get_client().list_customers()
+    return _filter_response(payload, "customer", verbosity)
+
+
+@mcp.tool()
+async def get_customer_info(end_user_id: str, verbosity: str = "standard") -> dict:
+    """Get a customer by end_user_id (`GET /customer/info`).
+
+    Args:
+        end_user_id: customer's stable end-user id.
+        verbosity: 'minimal' / 'standard' / 'full'.
+    """
+    payload = await get_client().get_customer_info(end_user_id)
+    return _filter_response(payload, "customer", verbosity)
+
+
+@mcp.tool()
+async def create_customer(
+    user_id: str,
+    alias: Optional[str] = None,
+    max_budget: Optional[float] = None,
+    soft_budget: Optional[float] = None,
+    budget_id: Optional[str] = None,
+    budget_duration: Optional[str] = None,
+    tpm_limit: Optional[int] = None,
+    rpm_limit: Optional[int] = None,
+    max_parallel_requests: Optional[int] = None,
+    blocked: Optional[bool] = None,
+    allowed_model_region: Optional[str] = None,
+    default_model: Optional[str] = None,
+    extras: Optional[dict] = None,
+) -> dict:
+    """Create a customer (`POST /customer/new`).
+
+    Args:
+        user_id: customer's stable end-user id (required).
+        extras: any NewCustomerRequest field not surfaced as a named arg.
+    """
+    return await get_client().create_customer(
+        user_id,
+        alias,
+        max_budget,
+        soft_budget,
+        budget_id,
+        budget_duration,
+        tpm_limit,
+        rpm_limit,
+        max_parallel_requests,
+        blocked,
+        allowed_model_region,
+        default_model,
+        extras,
+    )
+
+
+@mcp.tool()
+async def update_customer(
+    user_id: str,
+    alias: Optional[str] = None,
+    max_budget: Optional[float] = None,
+    budget_id: Optional[str] = None,
+    blocked: Optional[bool] = None,
+    allowed_model_region: Optional[str] = None,
+    default_model: Optional[str] = None,
+    extras: Optional[dict] = None,
+) -> dict:
+    """Update a customer (`POST /customer/update`).
+
+    UpdateCustomerRequest is intentionally narrower than NewCustomerRequest
+    upstream (no `tpm_limit` / `rpm_limit` / `max_parallel_requests`). Pass
+    less-common fields via `extras`.
+    """
+    return await get_client().update_customer(
+        user_id, alias, max_budget, budget_id, blocked, allowed_model_region, default_model, extras
+    )
+
+
+@mcp.tool()
+async def delete_customer(user_ids: list[str]) -> dict:
+    """Batch-delete customers (`POST /customer/delete`).
+
+    Args:
+        user_ids: list of customer ids to delete.
+    """
+    return await get_client().delete_customer(user_ids)
+
+
+@mcp.tool()
+async def set_customer_blocked(user_ids: list[str], blocked: bool) -> dict:
+    """Block or unblock customers.
+
+    Routes to `POST /customer/block` when `blocked=True`, else
+    `POST /customer/unblock`. Body in both cases is `{"user_ids": [...]}`.
+
+    Args:
+        user_ids: list of customer ids.
+        blocked: True to block, False to unblock.
+    """
+    return await get_client().set_customer_blocked(user_ids, blocked)
+
+
+@mcp.tool()
+async def get_customer_daily_activity(
+    end_user_ids: Optional[str] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    model: Optional[str] = None,
+    api_key: Optional[str] = None,
+    page: Optional[int] = None,
+    page_size: Optional[int] = None,
+    exclude_end_user_ids: Optional[str] = None,
+) -> dict:
+    """Per-customer daily activity (`GET /customer/daily/activity`).
+
+    Args:
+        start_date / end_date: ISO `YYYY-MM-DD`.
+        end_user_ids / exclude_end_user_ids: comma-separated customer ids.
+    """
+    return await get_client().get_customer_daily_activity(
+        end_user_ids,
+        start_date,
+        end_date,
+        model,
+        api_key,
+        page,
+        page_size,
+        exclude_end_user_ids,
+    )
+
+
+# ── Organization tools ──
+
+
+@mcp.tool()
+async def list_organizations(
+    org_id: Optional[str] = None,
+    org_alias: Optional[str] = None,
+    verbosity: str = "standard",
+) -> Any:
+    """List organizations (`GET /organization/list`).
+
+    Args:
+        verbosity: 'minimal' / 'standard' / 'full'.
+    """
+    payload = await get_client().list_organizations(org_id, org_alias)
+    return _filter_response(payload, "organization", verbosity)
+
+
+@mcp.tool()
+async def get_organization_info(organization_id: str, verbosity: str = "standard") -> dict:
+    """Get a single organization by id (`GET /organization/info`).
+
+    Args:
+        organization_id: organization id.
+        verbosity: 'minimal' / 'standard' / 'full'.
+    """
+    payload = await get_client().get_organization_info(organization_id)
+    return _filter_response(payload, "organization", verbosity)
+
+
+@mcp.tool()
+async def create_organization(
+    organization_alias: str,
+    organization_id: Optional[str] = None,
+    models: Optional[list[str]] = None,
+    max_budget: Optional[float] = None,
+    soft_budget: Optional[float] = None,
+    budget_id: Optional[str] = None,
+    budget_duration: Optional[str] = None,
+    tpm_limit: Optional[int] = None,
+    rpm_limit: Optional[int] = None,
+    max_parallel_requests: Optional[int] = None,
+    metadata: Optional[dict] = None,
+    extras: Optional[dict] = None,
+) -> dict:
+    """Create an organization (`POST /organization/new`).
+
+    Args:
+        organization_alias: human-readable name (required).
+        extras: less-common NewOrganizationRequest fields.
+    """
+    return await get_client().create_organization(
+        organization_alias,
+        organization_id,
+        models,
+        max_budget,
+        soft_budget,
+        budget_id,
+        budget_duration,
+        tpm_limit,
+        rpm_limit,
+        max_parallel_requests,
+        metadata,
+        extras,
+    )
+
+
+@mcp.tool()
+async def update_organization(
+    organization_id: str,
+    organization_alias: Optional[str] = None,
+    models: Optional[list[str]] = None,
+    max_budget: Optional[float] = None,
+    budget_duration: Optional[str] = None,
+    tpm_limit: Optional[int] = None,
+    rpm_limit: Optional[int] = None,
+    metadata: Optional[dict] = None,
+    extras: Optional[dict] = None,
+) -> dict:
+    """Patch an organization (`PATCH /organization/update`).
+
+    Upstream OpenAPI omits the request body schema for this endpoint; the
+    wrapper builds an UpdateOrganization payload mirroring NewOrganizationRequest.
+    Use `extras` for any field not surfaced as a named arg.
+    """
+    return await get_client().update_organization(
+        organization_id,
+        organization_alias,
+        models,
+        max_budget,
+        budget_duration,
+        tpm_limit,
+        rpm_limit,
+        metadata,
+        extras,
+    )
+
+
+@mcp.tool()
+async def delete_organization(organization_ids: list[str]) -> dict:
+    """Batch-delete organizations (`DELETE /organization/delete`).
+
+    DELETE with JSON body — `{"organization_ids": [...]}`.
+    """
+    return await get_client().delete_organization(organization_ids)
+
+
+@mcp.tool()
+async def add_org_member(
+    organization_id: str,
+    member: dict,
+    max_budget_in_organization: Optional[float] = None,
+) -> dict:
+    """Add a member to an organization (`POST /organization/member_add`).
+
+    Args:
+        organization_id: target org id.
+        member: upstream Member shape, e.g.
+            `{"user_id": "u-1", "role": "internal_user"}` or
+            `{"user_email": "alice@x.com", "role": "org_admin"}`.
+        max_budget_in_organization: per-member budget cap inside the org.
+    """
+    return await get_client().add_org_member(organization_id, member, max_budget_in_organization)
+
+
+@mcp.tool()
+async def update_org_member(
+    organization_id: str,
+    user_id: Optional[str] = None,
+    user_email: Optional[str] = None,
+    role: Optional[str] = None,
+    max_budget_in_organization: Optional[float] = None,
+) -> dict:
+    """Update an org member (`PATCH /organization/member_update`).
+
+    Identify the member by `user_id` or `user_email`. Only the fields you
+    pass are sent.
+    """
+    return await get_client().update_org_member(
+        organization_id, user_id, user_email, role, max_budget_in_organization
+    )
+
+
+@mcp.tool()
+async def delete_org_member(
+    organization_id: str,
+    user_id: Optional[str] = None,
+    user_email: Optional[str] = None,
+) -> dict:
+    """Remove an org member (`DELETE /organization/member_delete`).
+
+    Identify the member by `user_id` or `user_email`. DELETE with JSON body.
+    """
+    return await get_client().delete_org_member(organization_id, user_id, user_email)
+
+
+@mcp.tool()
+async def get_org_daily_activity(
+    organization_ids: Optional[str] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    model: Optional[str] = None,
+    api_key: Optional[str] = None,
+    page: Optional[int] = None,
+    page_size: Optional[int] = None,
+    exclude_organization_ids: Optional[str] = None,
+) -> dict:
+    """Per-org daily activity (`GET /organization/daily/activity`).
+
+    Args:
+        start_date / end_date: ISO `YYYY-MM-DD`.
+        organization_ids / exclude_organization_ids: comma-separated org ids.
+    """
+    return await get_client().get_org_daily_activity(
+        organization_ids,
+        start_date,
+        end_date,
+        model,
+        api_key,
+        page,
+        page_size,
+        exclude_organization_ids,
+    )
+
+
+# ── Project tools ──
+
+
+@mcp.tool()
+async def list_projects(verbosity: str = "standard") -> Any:
+    """List projects (`GET /project/list`).
+
+    Args:
+        verbosity: 'minimal' / 'standard' / 'full'.
+    """
+    payload = await get_client().list_projects()
+    return _filter_response(payload, "project", verbosity)
+
+
+@mcp.tool()
+async def get_project_info(project_id: str, verbosity: str = "standard") -> dict:
+    """Get a project by id (`GET /project/info`).
+
+    Args:
+        project_id: project id.
+        verbosity: 'minimal' / 'standard' / 'full'.
+    """
+    payload = await get_client().get_project_info(project_id)
+    return _filter_response(payload, "project", verbosity)
+
+
+@mcp.tool()
+async def create_project(
+    team_id: str,
+    project_id: Optional[str] = None,
+    project_alias: Optional[str] = None,
+    description: Optional[str] = None,
+    models: Optional[list[str]] = None,
+    max_budget: Optional[float] = None,
+    soft_budget: Optional[float] = None,
+    budget_duration: Optional[str] = None,
+    tpm_limit: Optional[int] = None,
+    rpm_limit: Optional[int] = None,
+    tags: Optional[list[str]] = None,
+    metadata: Optional[dict] = None,
+    guardrails: Optional[list[str]] = None,
+    blocked: Optional[bool] = None,
+    extras: Optional[dict] = None,
+) -> dict:
+    """Create a project (`POST /project/new`).
+
+    Args:
+        team_id: owning team (required — projects belong to teams).
+        extras: less-common NewProjectRequest fields.
+    """
+    return await get_client().create_project(
+        team_id,
+        project_id,
+        project_alias,
+        description,
+        models,
+        max_budget,
+        soft_budget,
+        budget_duration,
+        tpm_limit,
+        rpm_limit,
+        tags,
+        metadata,
+        guardrails,
+        blocked,
+        extras,
+    )
+
+
+@mcp.tool()
+async def update_project(
+    project_id: str,
+    project_alias: Optional[str] = None,
+    description: Optional[str] = None,
+    models: Optional[list[str]] = None,
+    max_budget: Optional[float] = None,
+    budget_duration: Optional[str] = None,
+    tpm_limit: Optional[int] = None,
+    rpm_limit: Optional[int] = None,
+    tags: Optional[list[str]] = None,
+    metadata: Optional[dict] = None,
+    guardrails: Optional[list[str]] = None,
+    blocked: Optional[bool] = None,
+    extras: Optional[dict] = None,
+) -> dict:
+    """Update a project (`POST /project/update`).
+
+    Only `project_id` is required.
+    """
+    return await get_client().update_project(
+        project_id,
+        project_alias,
+        description,
+        models,
+        max_budget,
+        budget_duration,
+        tpm_limit,
+        rpm_limit,
+        tags,
+        metadata,
+        guardrails,
+        blocked,
+        extras,
+    )
+
+
+@mcp.tool()
+async def delete_project(project_ids: list[str]) -> dict:
+    """Batch-delete projects (`DELETE /project/delete`).
+
+    DELETE with JSON body — `{"project_ids": [...]}`.
+    """
+    return await get_client().delete_project(project_ids)
+
+
+# ── Unified User Access Group tools ──
+
+
+@mcp.tool()
+async def list_user_access_groups(verbosity: str = "standard") -> Any:
+    """List unified user access groups (`GET /v1/unified_access_group`).
+
+    Distinct from `list_model_access_groups` (in #535) — unified access groups
+    gate users/teams against models, MCP servers, and agents in one shape.
+
+    Args:
+        verbosity: 'minimal' / 'standard' / 'full'.
+    """
+    payload = await get_client().list_user_access_groups()
+    return _filter_response(payload, "user_access_group", verbosity)
+
+
+@mcp.tool()
+async def get_user_access_group(access_group_id: str, verbosity: str = "standard") -> dict:
+    """Get a unified user access group by id (`GET /v1/unified_access_group/{id}`).
+
+    Args:
+        access_group_id: the group's id.
+        verbosity: 'minimal' / 'standard' / 'full'.
+    """
+    payload = await get_client().get_user_access_group(access_group_id)
+    return _filter_response(payload, "user_access_group", verbosity)
+
+
+@mcp.tool()
+async def create_user_access_group(
+    access_group_name: str,
+    description: Optional[str] = None,
+    access_model_names: Optional[list[str]] = None,
+    access_mcp_server_ids: Optional[list[str]] = None,
+    access_agent_ids: Optional[list[str]] = None,
+    assigned_team_ids: Optional[list[str]] = None,
+    assigned_key_ids: Optional[list[str]] = None,
+) -> dict:
+    """Create a unified user access group (`POST /v1/unified_access_group`).
+
+    Args:
+        access_group_name: human-readable name (required).
+        access_*: lists of resources this group grants access to (models / MCP
+            servers / agents).
+        assigned_*: lists of teams / keys this group is assigned to.
+    """
+    return await get_client().create_user_access_group(
+        access_group_name,
+        description,
+        access_model_names,
+        access_mcp_server_ids,
+        access_agent_ids,
+        assigned_team_ids,
+        assigned_key_ids,
+    )
+
+
+@mcp.tool()
+async def update_user_access_group(
+    access_group_id: str,
+    access_group_name: Optional[str] = None,
+    description: Optional[str] = None,
+    access_model_names: Optional[list[str]] = None,
+    access_mcp_server_ids: Optional[list[str]] = None,
+    access_agent_ids: Optional[list[str]] = None,
+    assigned_team_ids: Optional[list[str]] = None,
+    assigned_key_ids: Optional[list[str]] = None,
+) -> dict:
+    """Update a unified user access group (`PUT /v1/unified_access_group/{id}`).
+
+    All fields are optional; only the ones passed are sent. Note: this is
+    `PUT`, not `PATCH`, but the upstream merges sparsely.
+    """
+    return await get_client().update_user_access_group(
+        access_group_id,
+        access_group_name,
+        description,
+        access_model_names,
+        access_mcp_server_ids,
+        access_agent_ids,
+        assigned_team_ids,
+        assigned_key_ids,
+    )
+
+
+@mcp.tool()
+async def delete_user_access_group(access_group_id: str) -> dict:
+    """Delete a unified user access group (`DELETE /v1/unified_access_group/{id}`)."""
+    return await get_client().delete_user_access_group(access_group_id)
 
 
 # ── Entrypoint ──

--- a/tests/smoke.py
+++ b/tests/smoke.py
@@ -171,6 +171,121 @@ async def run() -> int:
             results.append(("get_key_info", True, "skipped (no virtual keys to probe)"))
         results.append(await _step("key_health", client.key_health()))
 
+        # Users family (2 read ops)
+        users_payload = await client.list_users(page_size=5)
+        results.append(("list_users", True, _summarize(users_payload)))
+        first_user_id = None
+        if isinstance(users_payload, dict):
+            for u in users_payload.get("users") or []:
+                if isinstance(u, dict) and u.get("user_id"):
+                    first_user_id = u["user_id"]
+                    break
+        elif isinstance(users_payload, list) and users_payload:
+            first_user_id = (
+                users_payload[0].get("user_id") if isinstance(users_payload[0], dict) else None
+            )
+        if first_user_id:
+            results.append(await _step("get_user_info", client.get_user_info(first_user_id)))
+        else:
+            results.append(("get_user_info", True, "skipped (no users)"))
+
+        # Customers family (2 read ops + daily activity)
+        customers = await client.list_customers()
+        results.append(("list_customers", True, _summarize(customers)))
+        first_customer = None
+        if isinstance(customers, list) and customers:
+            first_customer = (
+                customers[0] if isinstance(customers[0], str) else customers[0].get("user_id")
+            )
+        elif isinstance(customers, dict):
+            data = customers.get("data") or customers.get("customers") or []
+            if data:
+                first_customer = data[0] if isinstance(data[0], str) else data[0].get("user_id")
+        if first_customer:
+            try:
+                payload = await client.get_customer_info(first_customer)
+                results.append(("get_customer_info", True, _summarize(payload)))
+            except LiteLLMAPIError as e:
+                # Customer rows can be soft-deleted but still appear in list — 404 acceptable.
+                if e.status_code == 404:
+                    results.append(("get_customer_info", True, "404 (stale list entry)"))
+                else:
+                    results.append(("get_customer_info", False, f"APIError {e.status_code}: {e}"))
+        else:
+            results.append(("get_customer_info", True, "skipped (no customers)"))
+        # Daily-activity endpoints require start/end dates despite the
+        # OpenAPI marking them optional — upstream returns 400 if either is
+        # missing. Use a 30-day rolling window.
+        from datetime import date, timedelta
+
+        end_d = date.today().isoformat()
+        start_d = (date.today() - timedelta(days=30)).isoformat()
+        results.append(
+            await _step(
+                "get_customer_daily_activity",
+                client.get_customer_daily_activity(start_date=start_d, end_date=end_d, page=1),
+            )
+        )
+
+        # Organizations family (3 read ops)
+        orgs = await client.list_organizations()
+        results.append(("list_organizations", True, _summarize(orgs)))
+        first_org_id = None
+        if isinstance(orgs, list) and orgs:
+            first_org_id = orgs[0].get("organization_id") if isinstance(orgs[0], dict) else None
+        elif isinstance(orgs, dict):
+            data = orgs.get("data") or orgs.get("organizations") or []
+            if data:
+                first_org_id = data[0].get("organization_id") if isinstance(data[0], dict) else None
+        if first_org_id:
+            results.append(
+                await _step("get_organization_info", client.get_organization_info(first_org_id))
+            )
+        else:
+            results.append(("get_organization_info", True, "skipped (no orgs)"))
+        results.append(
+            await _step(
+                "get_org_daily_activity",
+                client.get_org_daily_activity(start_date=start_d, end_date=end_d, page=1),
+            )
+        )
+
+        # Projects family (2 read ops)
+        projects = await client.list_projects()
+        results.append(("list_projects", True, _summarize(projects)))
+        first_project_id = None
+        if isinstance(projects, list) and projects:
+            first_project_id = (
+                projects[0].get("project_id") if isinstance(projects[0], dict) else None
+            )
+        elif isinstance(projects, dict):
+            data = projects.get("data") or projects.get("projects") or []
+            if data:
+                first_project_id = data[0].get("project_id") if isinstance(data[0], dict) else None
+        if first_project_id:
+            results.append(
+                await _step("get_project_info", client.get_project_info(first_project_id))
+            )
+        else:
+            results.append(("get_project_info", True, "skipped (no projects)"))
+
+        # Unified Access Groups family (2 read ops)
+        uag = await client.list_user_access_groups()
+        results.append(("list_user_access_groups", True, _summarize(uag)))
+        first_uag_id = None
+        if isinstance(uag, list) and uag:
+            first_uag_id = uag[0].get("access_group_id") if isinstance(uag[0], dict) else None
+        elif isinstance(uag, dict):
+            data = uag.get("data") or uag.get("access_groups") or []
+            if data:
+                first_uag_id = data[0].get("access_group_id") if isinstance(data[0], dict) else None
+        if first_uag_id:
+            results.append(
+                await _step("get_user_access_group", client.get_user_access_group(first_uag_id))
+            )
+        else:
+            results.append(("get_user_access_group", True, "skipped (no user access groups)"))
+
     finally:
         await client.close()
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -528,6 +528,391 @@ class TestKeyHealth:
         mock_client.key_health.assert_awaited_once_with()
 
 
+class TestListUsers:
+    @pytest.mark.asyncio
+    async def test_no_filters(self, mock_client):
+        mock_client.list_users.return_value = {"users": [], "total_count": 0}
+        result = await src.server.list_users()
+        assert result == {"users": [], "total_count": 0}
+        mock_client.list_users.assert_awaited_once_with(
+            None, None, None, None, None, None, None, None, None, None
+        )
+
+    @pytest.mark.asyncio
+    async def test_filters_users_by_verbosity(self, mock_client):
+        mock_client.list_users.return_value = {
+            "users": [
+                {
+                    "user_id": "u-1",
+                    "user_email": "a@x.com",
+                    "user_role": "internal_user",
+                    "spend": 0.0,
+                    "extra": True,
+                }
+            ]
+        }
+        result = await src.server.list_users(verbosity="minimal")
+        assert result["users"] == [{"user_id": "u-1", "user_email": "a@x.com"}]
+
+    @pytest.mark.asyncio
+    async def test_filters_list_payload(self, mock_client):
+        mock_client.list_users.return_value = [
+            {"user_id": "u-1", "user_email": "a@x.com", "extra": True}
+        ]
+        result = await src.server.list_users(verbosity="minimal")
+        assert result == [{"user_id": "u-1", "user_email": "a@x.com"}]
+
+
+class TestGetUserInfo:
+    @pytest.mark.asyncio
+    async def test_no_user_id(self, mock_client):
+        mock_client.get_user_info.return_value = {"user_id": "u-self", "user_email": "me@x.com"}
+        await src.server.get_user_info()
+        mock_client.get_user_info.assert_awaited_once_with(None)
+
+    @pytest.mark.asyncio
+    async def test_with_user_id(self, mock_client):
+        mock_client.get_user_info.return_value = {
+            "user_id": "u-1",
+            "user_email": "a@x.com",
+            "user_role": "internal_user",
+        }
+        result = await src.server.get_user_info("u-1", "minimal")
+        assert result == {"user_id": "u-1", "user_email": "a@x.com"}
+        mock_client.get_user_info.assert_awaited_once_with("u-1")
+
+
+class TestCreateUser:
+    @pytest.mark.asyncio
+    async def test_minimal(self, mock_client):
+        mock_client.create_user.return_value = {"user_id": "u-1"}
+        await src.server.create_user(user_email="a@x.com")
+        call = mock_client.create_user.await_args
+        assert call.args[0] == "a@x.com"
+
+    @pytest.mark.asyncio
+    async def test_extras_passthrough(self, mock_client):
+        mock_client.create_user.return_value = {"user_id": "u-1"}
+        await src.server.create_user(
+            user_email="a@x.com", extras={"permissions": {"can_create_keys": True}}
+        )
+        call = mock_client.create_user.await_args
+        assert call.args[16] == {"permissions": {"can_create_keys": True}}
+
+
+class TestUpdateUser:
+    @pytest.mark.asyncio
+    async def test_required_user_id(self, mock_client):
+        mock_client.update_user.return_value = {"user_id": "u-1"}
+        await src.server.update_user("u-1", max_budget=50.0)
+        mock_client.update_user.assert_awaited_once_with(
+            "u-1", None, None, None, None, None, 50.0, None, None, None, None, None, None, None
+        )
+
+
+class TestDeleteUser:
+    @pytest.mark.asyncio
+    async def test_passes_ids(self, mock_client):
+        mock_client.delete_user.return_value = {"deleted": 2}
+        await src.server.delete_user(["u-1", "u-2"])
+        mock_client.delete_user.assert_awaited_once_with(["u-1", "u-2"])
+
+
+class TestListCustomers:
+    @pytest.mark.asyncio
+    async def test_passthrough_full(self, mock_client):
+        payload = [{"user_id": "c-1", "alias": "Acme", "extra": True}]
+        mock_client.list_customers.return_value = payload
+        assert await src.server.list_customers("full") == payload
+
+    @pytest.mark.asyncio
+    async def test_minimal_filters(self, mock_client):
+        mock_client.list_customers.return_value = [
+            {"user_id": "c-1", "alias": "Acme", "max_budget": 100.0}
+        ]
+        result = await src.server.list_customers("minimal")
+        assert result == [{"user_id": "c-1", "alias": "Acme"}]
+
+
+class TestGetCustomerInfo:
+    @pytest.mark.asyncio
+    async def test_passes_end_user_id(self, mock_client):
+        mock_client.get_customer_info.return_value = {"user_id": "c-1", "alias": "Acme"}
+        await src.server.get_customer_info("c-1", "full")
+        mock_client.get_customer_info.assert_awaited_once_with("c-1")
+
+
+class TestCreateCustomer:
+    @pytest.mark.asyncio
+    async def test_required_user_id(self, mock_client):
+        mock_client.create_customer.return_value = {"user_id": "c-1"}
+        await src.server.create_customer("c-1", alias="Acme", max_budget=100.0)
+        call = mock_client.create_customer.await_args
+        assert call.args[0] == "c-1"
+        assert call.args[1] == "Acme"
+        assert call.args[2] == 100.0
+
+
+class TestUpdateCustomer:
+    @pytest.mark.asyncio
+    async def test_minimal(self, mock_client):
+        mock_client.update_customer.return_value = {"user_id": "c-1"}
+        await src.server.update_customer("c-1", max_budget=200.0)
+        mock_client.update_customer.assert_awaited_once_with(
+            "c-1", None, 200.0, None, None, None, None, None
+        )
+
+
+class TestDeleteCustomer:
+    @pytest.mark.asyncio
+    async def test_passes_ids(self, mock_client):
+        mock_client.delete_customer.return_value = {"deleted": 1}
+        await src.server.delete_customer(["c-1"])
+        mock_client.delete_customer.assert_awaited_once_with(["c-1"])
+
+
+class TestSetCustomerBlocked:
+    @pytest.mark.asyncio
+    async def test_block(self, mock_client):
+        mock_client.set_customer_blocked.return_value = {"ok": True}
+        await src.server.set_customer_blocked(["c-1"], True)
+        mock_client.set_customer_blocked.assert_awaited_once_with(["c-1"], True)
+
+    @pytest.mark.asyncio
+    async def test_unblock(self, mock_client):
+        mock_client.set_customer_blocked.return_value = {"ok": True}
+        await src.server.set_customer_blocked(["c-1", "c-2"], False)
+        mock_client.set_customer_blocked.assert_awaited_once_with(["c-1", "c-2"], False)
+
+
+class TestGetCustomerDailyActivity:
+    @pytest.mark.asyncio
+    async def test_passes_dates(self, mock_client):
+        mock_client.get_customer_daily_activity.return_value = {"data": []}
+        await src.server.get_customer_daily_activity(
+            start_date="2026-04-01", end_date="2026-04-30", page=1
+        )
+        mock_client.get_customer_daily_activity.assert_awaited_once_with(
+            None, "2026-04-01", "2026-04-30", None, None, 1, None, None
+        )
+
+
+class TestListOrganizations:
+    @pytest.mark.asyncio
+    async def test_no_filters(self, mock_client):
+        mock_client.list_organizations.return_value = [{"organization_id": "o-1"}]
+        await src.server.list_organizations()
+        mock_client.list_organizations.assert_awaited_once_with(None, None)
+
+    @pytest.mark.asyncio
+    async def test_filter_by_alias(self, mock_client):
+        mock_client.list_organizations.return_value = []
+        await src.server.list_organizations(org_alias="acme")
+        mock_client.list_organizations.assert_awaited_once_with(None, "acme")
+
+
+class TestGetOrganizationInfo:
+    @pytest.mark.asyncio
+    async def test_passes_id(self, mock_client):
+        mock_client.get_organization_info.return_value = {
+            "organization_id": "o-1",
+            "organization_alias": "Acme",
+        }
+        result = await src.server.get_organization_info("o-1", "minimal")
+        assert result == {"organization_id": "o-1", "organization_alias": "Acme"}
+
+
+class TestCreateOrganization:
+    @pytest.mark.asyncio
+    async def test_required_alias(self, mock_client):
+        mock_client.create_organization.return_value = {"organization_id": "o-1"}
+        await src.server.create_organization("Acme", max_budget=1000.0)
+        call = mock_client.create_organization.await_args
+        assert call.args[0] == "Acme"
+        assert call.args[3] == 1000.0
+
+
+class TestUpdateOrganization:
+    @pytest.mark.asyncio
+    async def test_required_id(self, mock_client):
+        mock_client.update_organization.return_value = {"ok": True}
+        await src.server.update_organization("o-1", max_budget=2000.0)
+        mock_client.update_organization.assert_awaited_once_with(
+            "o-1", None, None, 2000.0, None, None, None, None, None
+        )
+
+    @pytest.mark.asyncio
+    async def test_extras_merged(self, mock_client):
+        mock_client.update_organization.return_value = {"ok": True}
+        await src.server.update_organization("o-1", extras={"object_permission": {}})
+        call = mock_client.update_organization.await_args
+        assert call.args[8] == {"object_permission": {}}
+
+
+class TestDeleteOrganization:
+    @pytest.mark.asyncio
+    async def test_passes_ids(self, mock_client):
+        mock_client.delete_organization.return_value = {"deleted": 1}
+        await src.server.delete_organization(["o-1"])
+        mock_client.delete_organization.assert_awaited_once_with(["o-1"])
+
+
+class TestAddOrgMember:
+    @pytest.mark.asyncio
+    async def test_minimal(self, mock_client):
+        mock_client.add_org_member.return_value = {"ok": True}
+        await src.server.add_org_member("o-1", {"user_id": "u-1", "role": "internal_user"})
+        mock_client.add_org_member.assert_awaited_once_with(
+            "o-1", {"user_id": "u-1", "role": "internal_user"}, None
+        )
+
+    @pytest.mark.asyncio
+    async def test_with_budget(self, mock_client):
+        mock_client.add_org_member.return_value = {"ok": True}
+        await src.server.add_org_member("o-1", {"user_email": "a@x.com", "role": "org_admin"}, 50.0)
+        mock_client.add_org_member.assert_awaited_once_with(
+            "o-1", {"user_email": "a@x.com", "role": "org_admin"}, 50.0
+        )
+
+
+class TestUpdateOrgMember:
+    @pytest.mark.asyncio
+    async def test_role_change(self, mock_client):
+        mock_client.update_org_member.return_value = {"ok": True}
+        await src.server.update_org_member("o-1", user_id="u-1", role="org_admin")
+        mock_client.update_org_member.assert_awaited_once_with(
+            "o-1", "u-1", None, "org_admin", None
+        )
+
+
+class TestDeleteOrgMember:
+    @pytest.mark.asyncio
+    async def test_by_email(self, mock_client):
+        mock_client.delete_org_member.return_value = {"ok": True}
+        await src.server.delete_org_member("o-1", user_email="a@x.com")
+        mock_client.delete_org_member.assert_awaited_once_with("o-1", None, "a@x.com")
+
+
+class TestGetOrgDailyActivity:
+    @pytest.mark.asyncio
+    async def test_passes_filters(self, mock_client):
+        mock_client.get_org_daily_activity.return_value = {"data": []}
+        await src.server.get_org_daily_activity(organization_ids="o-1,o-2", start_date="2026-04-01")
+        mock_client.get_org_daily_activity.assert_awaited_once_with(
+            "o-1,o-2", "2026-04-01", None, None, None, None, None, None
+        )
+
+
+class TestListProjects:
+    @pytest.mark.asyncio
+    async def test_passthrough(self, mock_client):
+        mock_client.list_projects.return_value = [{"project_id": "p-1"}]
+        result = await src.server.list_projects("full")
+        assert result == [{"project_id": "p-1"}]
+
+
+class TestGetProjectInfo:
+    @pytest.mark.asyncio
+    async def test_passes_id(self, mock_client):
+        mock_client.get_project_info.return_value = {
+            "project_id": "p-1",
+            "project_alias": "Phoenix",
+        }
+        result = await src.server.get_project_info("p-1", "minimal")
+        assert result == {"project_id": "p-1", "project_alias": "Phoenix"}
+
+
+class TestCreateProject:
+    @pytest.mark.asyncio
+    async def test_required_team_id(self, mock_client):
+        mock_client.create_project.return_value = {"project_id": "p-1"}
+        await src.server.create_project("t-1", project_alias="Phoenix", max_budget=500.0)
+        call = mock_client.create_project.await_args
+        assert call.args[0] == "t-1"
+        assert call.args[2] == "Phoenix"
+        assert call.args[5] == 500.0
+
+
+class TestUpdateProject:
+    @pytest.mark.asyncio
+    async def test_required_id(self, mock_client):
+        mock_client.update_project.return_value = {"ok": True}
+        await src.server.update_project("p-1", max_budget=1000.0)
+        mock_client.update_project.assert_awaited_once_with(
+            "p-1", None, None, None, 1000.0, None, None, None, None, None, None, None, None
+        )
+
+
+class TestDeleteProject:
+    @pytest.mark.asyncio
+    async def test_passes_ids(self, mock_client):
+        mock_client.delete_project.return_value = {"deleted": 1}
+        await src.server.delete_project(["p-1", "p-2"])
+        mock_client.delete_project.assert_awaited_once_with(["p-1", "p-2"])
+
+
+class TestListUserAccessGroups:
+    @pytest.mark.asyncio
+    async def test_passthrough(self, mock_client):
+        mock_client.list_user_access_groups.return_value = [
+            {"access_group_id": "ag-1", "access_group_name": "engineering"}
+        ]
+        result = await src.server.list_user_access_groups("full")
+        assert result == [{"access_group_id": "ag-1", "access_group_name": "engineering"}]
+
+
+class TestGetUserAccessGroup:
+    @pytest.mark.asyncio
+    async def test_passes_id(self, mock_client):
+        mock_client.get_user_access_group.return_value = {
+            "access_group_id": "ag-1",
+            "access_group_name": "engineering",
+        }
+        result = await src.server.get_user_access_group("ag-1", "minimal")
+        assert result == {"access_group_id": "ag-1", "access_group_name": "engineering"}
+
+
+class TestCreateUserAccessGroup:
+    @pytest.mark.asyncio
+    async def test_minimal(self, mock_client):
+        mock_client.create_user_access_group.return_value = {"access_group_id": "ag-1"}
+        await src.server.create_user_access_group("engineering")
+        mock_client.create_user_access_group.assert_awaited_once_with(
+            "engineering", None, None, None, None, None, None
+        )
+
+    @pytest.mark.asyncio
+    async def test_with_members(self, mock_client):
+        mock_client.create_user_access_group.return_value = {"access_group_id": "ag-1"}
+        await src.server.create_user_access_group(
+            "engineering",
+            description="eng team",
+            access_model_names=["gpt-4o"],
+            assigned_team_ids=["t-1"],
+        )
+        mock_client.create_user_access_group.assert_awaited_once_with(
+            "engineering", "eng team", ["gpt-4o"], None, None, ["t-1"], None
+        )
+
+
+class TestUpdateUserAccessGroup:
+    @pytest.mark.asyncio
+    async def test_replace_models(self, mock_client):
+        mock_client.update_user_access_group.return_value = {"ok": True}
+        await src.server.update_user_access_group("ag-1", access_model_names=["claude-opus-4-7"])
+        mock_client.update_user_access_group.assert_awaited_once_with(
+            "ag-1", None, None, ["claude-opus-4-7"], None, None, None, None
+        )
+
+
+class TestDeleteUserAccessGroup:
+    @pytest.mark.asyncio
+    async def test_passes_id(self, mock_client):
+        mock_client.delete_user_access_group.return_value = {"deleted": True}
+        await src.server.delete_user_access_group("ag-1")
+        mock_client.delete_user_access_group.assert_awaited_once_with("ag-1")
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client

--- a/uv.lock
+++ b/uv.lock
@@ -546,7 +546,7 @@ wheels = [
 
 [[package]]
 name = "litellm-mcp"
-version = "0.1.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Implements US [#536 — litellm-mcp Identity, Members & Access Groups](https://taiga.tetra-ai.fr/project/tetra/us/536) (Epic [#454 LLM Platform](https://taiga.tetra-ai.fr/project/tetra/epic/454), swimlane 18 LiteLLM MCP Build).

Adds 31 admin tools across 5 LiteLLM identity-stack families:

| Family | Tools | Endpoints |
|---|---:|---|
| Internal Users | 5 | `/user/list,info,new,update,delete` |
| Customers | 7 | `/customer/list,info,new,update,delete,block,unblock,daily/activity` |
| Organizations | 9 | `/organization/list,info,new,update,delete,member_add,member_update,member_delete,daily/activity` |
| Projects | 5 | `/project/list,info,new,update,delete` |
| Unified User Access Groups | 5 | `/v1/unified_access_group/*` |

**Conventions carried from #535 (v1.1.0):**
- `extras: Optional[dict]` long-tail on `create_user`/`update_user`, `create_customer`/`update_customer`, `create_organization`/`update_organization`, `create_project`/`update_project` — surface ~12 common fields, accept the rest via `extras` (merged into the body via the new shared `_build_body` helper, generalizing `_build_key_body`).
- Verb-collapsing wrapper: `set_customer_blocked(blocked: bool)` routes to `/customer/block` | `/customer/unblock` with a single tool surface.
- `RESPONSE_FIELDS` shapes for `user`, `customer`, `organization`, `project`, `user_access_group` with `minimal` / `standard` / `full` projections.

**Upstream quirks captured in docstrings (live smoke caught these):**
- `GET /customer/daily/activity` and `GET /organization/daily/activity` require `start_date` and `end_date` despite the OpenAPI spec marking them optional — calls without either return HTTP 400.
- `PATCH /organization/update` has no documented request body in upstream OpenAPI; wrapper sends an UpdateOrganization payload mirroring `NewOrganizationRequest`.
- `delete_organization` and `delete_project` use `DELETE` with a JSON body (supported by httpx).

**Distinct from #535 model-access-groups:** the new unified-user-access-group family wraps `/v1/unified_access_group/*` and gates users/teams against models, MCP servers, and agents in one shape — separate from the `/access_group/*` model-access-groups shipped in v1.1.0.

## Test plan

- [x] Unit tests: 41 new test classes in `tests/test_server.py` against `AsyncMock(LiteLLMClient)` — 93 tests total pass (52 from #535 + 41 new) in ~0.9s.
- [x] Live read-only smoke against local LiteLLM v1.83.7-stable: 27/27 pass (15 from #535 + 12 new).
- [x] `ruff check` + `ruff format --check` clean (pre-commit hooks).
- [ ] CI green on this PR.
- [ ] Verify semrel cuts `v1.2.0` from the 2 `feat:` commits on merge.

Refs: Taiga US #536 (tasks #597–#631).