### PR TITLE
feat: spend/exec/health tools (US #596 — 19 tools, semrel 1.x.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,16 +14,17 @@ MCP server for the LiteLLM proxy. Python 3.12, fastmcp (`mcp.server.fastmcp`), h
 ## Conventions
 
 - All read-shaped tools accept a `verbosity: str` argument (`minimal` / `standard` / `full`) and route through `_filter_response`. Write/admin tools generally don't filter (`update_model`, `add_model`, etc. return upstream as-is).
-- Add new resource shapes to `RESPONSE_FIELDS` in `src/server.py`. Current shapes: `model`, `access_group`, `credential`, `key`, `public_hub`, `user`, `customer`, `organization`, `project`, `user_access_group`. The `credential.standard` shape intentionally drops `credential_values` to avoid leaking secrets — use `full` to inspect.
+- Add new resource shapes to `RESPONSE_FIELDS` in `src/server.py`. Current shapes: `model`, `access_group`, `credential`, `key`, `public_hub`, `user`, `customer`, `organization`, `project`, `user_access_group`, `budget`, `spend_record`, `chat_completion`, `embedding`, `health`. The `credential.standard` shape intentionally drops `credential_values` to avoid leaking secrets — use `full` to inspect.
 - New endpoints go on `LiteLLMClient` first, then a thin `@mcp.tool()` wrapper in `server.py`.
 - For body schemas with many optional fields (`GenerateKeyRequest`, `UpdateKeyRequest`, `RegenerateKeyRequest`, `NewUserRequest`, `NewCustomerRequest`, `NewOrganizationRequest`, `NewProjectRequest`), expose ~12 common fields as named args and accept the long tail through an `extras: Optional[dict]` argument (merged into the body via `_build_body`/`_build_key_body`).
 - Keep transport agnostic: never call `print` / write to stdout in stdio mode.
 
-## Current scope (US #534 + #535 + #536)
+## Current scope (US #534 + #535 + #536 + #596)
 
 - **#534 (v1.0.0):** foundation, `list_models`.
 - **#535 (v1.1.0):** 32 admin tools — Models (5), Model Hub (5), Access Groups (5), Credentials (6), Keys (11). All wrapped with unit tests against `AsyncMock(LiteLLMClient)`.
-- **#536:** 31 identity tools — Internal Users (5), Customers (7), Organizations (9, incl. member CRUD), Projects (5), Unified User Access Groups (5). Same test/smoke conventions.
+- **#536 (v1.2.0):** 31 identity tools — Internal Users (5), Customers (7), Organizations (9, incl. member CRUD), Projects (5), Unified User Access Groups (5).
+- **#596:** 19 tools — Budgets (6), Spend (5), Execution (3 — chat/completion/embed, synchronous), Health (5). Same test/smoke conventions.
 
 ### Upstream quirks
 
@@ -32,6 +33,10 @@ MCP server for the LiteLLM proxy. Python 3.12, fastmcp (`mcp.server.fastmcp`), h
 - `PATCH /credentials/{name}` is a full replace despite the verb; `CredentialItem` requires all three body fields.
 - `GET /customer/daily/activity` and `GET /organization/daily/activity` require `start_date` and `end_date` despite the OpenAPI marking them optional — omit either and you get HTTP 400.
 - `PATCH /organization/update` has no documented request body in the OpenAPI spec; the wrapper sends an UpdateOrganization payload mirroring NewOrganizationRequest.
+- `POST /budget/info` is a batch GET — it takes a body `{"budgets": [...]}` rather than a single-id query, despite the GET-shaped name.
+- `POST /v1/completions` only documents a `model` query param in the OpenAPI spec but accepts the full OpenAI-shaped body. The wrapper sends `model` in both query and body.
+- `GET /global/spend/report` is gated behind a LiteLLM Enterprise license — community-tier proxies return HTTP 400 "You must be a LiteLLM Enterprise user". The wrapper passes the call through unchanged.
+- Execution tools (`chat_completion` / `completion` / `embed`) are synchronous; `stream` is stripped from the body. Streaming would require a different MCP transport contract — revisit as a follow-on if needed.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,12 @@ MCP server for [LiteLLM](https://github.com/BerriAI/litellm) proxy administratio
 
 Foundation (US #534) shipped `list_models`. Admin slice (US #535) added 32 tools
 covering models, model hub, model access groups, credentials, and virtual keys.
-Identity slice (US #536) adds 31 tools covering internal users, customers,
+Identity slice (US #536) added 31 tools covering internal users, customers,
 organizations (with member management), projects, and unified user access
-groups. Subsequent slices add spend/execution (#536b), governance and
-passthrough (#538), and the MCP-of-MCPs gateway (#558).
+groups. Spend/execution/health slice (US #596) adds 19 tools covering budgets,
+spend reporting, the three core execution verbs (chat / completion / embed),
+and admin health probes. Subsequent slices add governance and passthrough
+(#538) and the MCP-of-MCPs gateway (#558).
 
 ## Setup
 
@@ -198,6 +200,52 @@ groups gate users/teams against models, MCP servers, and agents in one shape.
 `create_organization`, `update_organization`, `create_project`, and
 `update_project` accept an `extras: dict` argument for the long tail of
 upstream fields not surfaced as named args.
+
+### Budgets (6)
+
+| Tool | Endpoint |
+|------|----------|
+| `list_budgets` | `GET /budget/list` |
+| `get_budget_info` | `POST /budget/info` (batch lookup by id list) |
+| `create_budget` | `POST /budget/new` |
+| `update_budget` | `POST /budget/update` |
+| `delete_budget` | `POST /budget/delete` |
+| `get_budget_settings` | `GET /budget/settings` |
+
+`create_budget` and `update_budget` accept an `extras: dict` for any
+`BudgetNewRequest` field not surfaced as a named arg.
+
+### Spend (5)
+
+| Tool | Endpoint |
+|------|----------|
+| `get_global_spend_report` | `GET /global/spend/report` (LiteLLM Enterprise only) |
+| `list_spend_logs` | `GET /spend/logs` |
+| `list_spend_tags` | `GET /spend/tags` |
+| `calculate_spend` | `POST /spend/calculate` (prospective or retrospective) |
+| `get_user_daily_activity` | `GET /user/daily/activity` |
+
+### Execution (3)
+
+| Tool | Endpoint |
+|------|----------|
+| `chat_completion` | `POST /v1/chat/completions` |
+| `completion` | `POST /v1/completions` (legacy text) |
+| `embed` | `POST /v1/embeddings` |
+
+Synchronous only — `stream` is stripped from the body. Pass any extra
+OpenAI/LiteLLM body fields (temperature, max_tokens, tools, dimensions, etc.)
+via the `body: dict` argument.
+
+### Health (5)
+
+| Tool | Endpoint |
+|------|----------|
+| `check_health` | `GET /health` (probes router-registered deployments) |
+| `check_health_backlog` | `GET /health/backlog` |
+| `get_health_history` | `GET /health/history` |
+| `get_health_latest` | `GET /health/latest` |
+| `test_model_connection` | `POST /health/test_connection` |
 
 ## Development
 

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -1245,3 +1245,346 @@ class LiteLLMClient:
     async def delete_user_access_group(self, access_group_id: str) -> dict:
         """Delete a unified user access group (`DELETE /v1/unified_access_group/{id}`)."""
         return await self._request("DELETE", f"/v1/unified_access_group/{access_group_id}")
+
+    # ── Budget operations ──
+
+    async def list_budgets(self) -> Any:
+        """List configured budgets (`GET /budget/list`)."""
+        return await self._request("GET", "/budget/list")
+
+    async def get_budget_info(self, budgets: list[str]) -> Any:
+        """Get info about one or more budgets (`POST /budget/info`).
+
+        Body shape is `{"budgets": [...]}` — the upstream `BudgetRequest` schema
+        treats this as a batch lookup, not a single-id GET.
+        """
+        return await self._request("POST", "/budget/info", json={"budgets": budgets})
+
+    async def create_budget(
+        self,
+        budget_id: Optional[str] = None,
+        max_budget: Optional[float] = None,
+        soft_budget: Optional[float] = None,
+        max_parallel_requests: Optional[int] = None,
+        tpm_limit: Optional[int] = None,
+        rpm_limit: Optional[int] = None,
+        budget_duration: Optional[str] = None,
+        model_max_budget: Optional[dict] = None,
+        budget_reset_at: Optional[str] = None,
+        extras: Optional[dict] = None,
+    ) -> dict:
+        """Create a budget (`POST /budget/new`).
+
+        All fields optional per upstream `BudgetNewRequest`. `model_max_budget`
+        is a per-model cap mapping like `{"gpt-4o": {"budget_limit": 10.0}}`.
+        """
+        body = self._build_body(
+            {
+                "budget_id": budget_id,
+                "max_budget": max_budget,
+                "soft_budget": soft_budget,
+                "max_parallel_requests": max_parallel_requests,
+                "tpm_limit": tpm_limit,
+                "rpm_limit": rpm_limit,
+                "budget_duration": budget_duration,
+                "model_max_budget": model_max_budget,
+                "budget_reset_at": budget_reset_at,
+            },
+            extras,
+        )
+        return await self._request("POST", "/budget/new", json=body)
+
+    async def update_budget(
+        self,
+        budget_id: str,
+        max_budget: Optional[float] = None,
+        soft_budget: Optional[float] = None,
+        max_parallel_requests: Optional[int] = None,
+        tpm_limit: Optional[int] = None,
+        rpm_limit: Optional[int] = None,
+        budget_duration: Optional[str] = None,
+        model_max_budget: Optional[dict] = None,
+        budget_reset_at: Optional[str] = None,
+        extras: Optional[dict] = None,
+    ) -> dict:
+        """Update a budget (`POST /budget/update`).
+
+        Same `BudgetNewRequest` shape as create — `budget_id` identifies the row.
+        """
+        body = self._build_body(
+            {
+                "budget_id": budget_id,
+                "max_budget": max_budget,
+                "soft_budget": soft_budget,
+                "max_parallel_requests": max_parallel_requests,
+                "tpm_limit": tpm_limit,
+                "rpm_limit": rpm_limit,
+                "budget_duration": budget_duration,
+                "model_max_budget": model_max_budget,
+                "budget_reset_at": budget_reset_at,
+            },
+            extras,
+        )
+        return await self._request("POST", "/budget/update", json=body)
+
+    async def delete_budget(self, budget_id: str) -> dict:
+        """Delete a budget (`POST /budget/delete`).
+
+        Body is `{"id": <budget_id>}` per upstream `BudgetDeleteRequest`.
+        """
+        return await self._request("POST", "/budget/delete", json={"id": budget_id})
+
+    async def get_budget_settings(self, budget_id: str) -> dict:
+        """Get effective budget settings (`GET /budget/settings`).
+
+        `budget_id` is a required query param.
+        """
+        return await self._request("GET", "/budget/settings", params={"budget_id": budget_id})
+
+    # ── Spend operations ──
+
+    async def get_global_spend_report(
+        self,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        group_by: Optional[str] = None,
+        api_key: Optional[str] = None,
+        internal_user_id: Optional[str] = None,
+        team_id: Optional[str] = None,
+        customer_id: Optional[str] = None,
+    ) -> Any:
+        """Aggregated global spend report (`GET /global/spend/report`).
+
+        All filters are optional query params. `group_by` accepts upstream-defined
+        values like `team`, `customer`, `api_key`, `model`.
+        """
+        params = {
+            k: v
+            for k, v in {
+                "start_date": start_date,
+                "end_date": end_date,
+                "group_by": group_by,
+                "api_key": api_key,
+                "internal_user_id": internal_user_id,
+                "team_id": team_id,
+                "customer_id": customer_id,
+            }.items()
+            if v is not None
+        }
+        return await self._request("GET", "/global/spend/report", params=params or None)
+
+    async def list_spend_logs(
+        self,
+        api_key: Optional[str] = None,
+        user_id: Optional[str] = None,
+        request_id: Optional[str] = None,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        summarize: Optional[bool] = None,
+    ) -> Any:
+        """List per-request spend logs (`GET /spend/logs`).
+
+        All filters are optional. `summarize=True` returns aggregated rows.
+        """
+        params = {
+            k: v
+            for k, v in {
+                "api_key": api_key,
+                "user_id": user_id,
+                "request_id": request_id,
+                "start_date": start_date,
+                "end_date": end_date,
+                "summarize": summarize,
+            }.items()
+            if v is not None
+        }
+        return await self._request("GET", "/spend/logs", params=params or None)
+
+    async def list_spend_tags(
+        self,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+    ) -> Any:
+        """List distinct spend tags within a date window (`GET /spend/tags`)."""
+        params = {
+            k: v
+            for k, v in {"start_date": start_date, "end_date": end_date}.items()
+            if v is not None
+        }
+        return await self._request("GET", "/spend/tags", params=params or None)
+
+    async def calculate_spend(
+        self,
+        model: Optional[str] = None,
+        messages: Optional[list[dict]] = None,
+        completion_response: Optional[dict] = None,
+    ) -> dict:
+        """Estimate spend for a request (`POST /spend/calculate`).
+
+        Per upstream `SpendCalculateRequest`, callers can either:
+        - pass `model + messages` for a prospective cost estimate, or
+        - pass `model + completion_response` for a retrospective re-cost.
+        """
+        body = self._build_body(
+            {
+                "model": model,
+                "messages": messages,
+                "completion_response": completion_response,
+            }
+        )
+        return await self._request("POST", "/spend/calculate", json=body)
+
+    async def get_user_daily_activity(
+        self,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        model: Optional[str] = None,
+        api_key: Optional[str] = None,
+        user_id: Optional[str] = None,
+        page: Optional[int] = None,
+        page_size: Optional[int] = None,
+        timezone: Optional[str] = None,
+    ) -> dict:
+        """Per-user daily activity (`GET /user/daily/activity`).
+
+        Mirrors the customer/org daily-activity shape but scoped to the
+        internal-user dimension. Supplying `start_date` / `end_date` is
+        recommended (the upstream has been observed to reject open-ended ranges
+        on related endpoints).
+        """
+        params = {
+            k: v
+            for k, v in {
+                "start_date": start_date,
+                "end_date": end_date,
+                "model": model,
+                "api_key": api_key,
+                "user_id": user_id,
+                "page": page,
+                "page_size": page_size,
+                "timezone": timezone,
+            }.items()
+            if v is not None
+        }
+        return await self._request("GET", "/user/daily/activity", params=params or None)
+
+    # ── Execution operations ──
+
+    async def chat_completion(
+        self,
+        model: str,
+        messages: list[dict],
+        body: Optional[dict] = None,
+    ) -> dict:
+        """Chat completion (`POST /v1/chat/completions`).
+
+        Synchronous only — streaming is not exposed in this slice (would need a
+        different transport contract on the MCP side). Pass any extra OpenAI /
+        LiteLLM body fields (temperature, max_tokens, tools, etc.) via `body`.
+        """
+        payload: dict[str, Any] = dict(body) if body else {}
+        payload["model"] = model
+        payload["messages"] = messages
+        payload.pop("stream", None)
+        return await self._request("POST", "/v1/chat/completions", json=payload)
+
+    async def completion(
+        self,
+        model: str,
+        prompt: str,
+        body: Optional[dict] = None,
+    ) -> dict:
+        """Legacy text completion (`POST /v1/completions`).
+
+        OpenAPI declares only a `model` query param and no body schema, but the
+        upstream still accepts the OpenAI-shaped body (`prompt`, `max_tokens`,
+        etc.). We send `model` in both query and body to satisfy both routing
+        paths.
+        """
+        payload: dict[str, Any] = dict(body) if body else {}
+        payload["model"] = model
+        payload["prompt"] = prompt
+        payload.pop("stream", None)
+        return await self._request("POST", "/v1/completions", params={"model": model}, json=payload)
+
+    async def embed(
+        self,
+        model: str,
+        input: list[str],
+        body: Optional[dict] = None,
+    ) -> dict:
+        """Generate embeddings (`POST /v1/embeddings`).
+
+        Pass any extra fields (e.g. `dimensions`, `encoding_format`, `user`)
+        via `body`. `input` is a list of strings; single-string callers should
+        wrap as `[text]`.
+        """
+        payload: dict[str, Any] = dict(body) if body else {}
+        payload["model"] = model
+        payload["input"] = input
+        return await self._request("POST", "/v1/embeddings", json=payload)
+
+    # ── Health operations ──
+
+    async def check_health(
+        self,
+        model: Optional[str] = None,
+        model_id: Optional[str] = None,
+    ) -> dict:
+        """Run upstream health checks against deployments (`GET /health`).
+
+        Optionally narrow to a single deployment via `model` (model_name alias)
+        or `model_id` (litellm internal id).
+        """
+        params = {k: v for k, v in {"model": model, "model_id": model_id}.items() if v is not None}
+        return await self._request("GET", "/health", params=params or None)
+
+    async def check_health_backlog(self) -> dict:
+        """Get health-check queue backlog (`GET /health/backlog`)."""
+        return await self._request("GET", "/health/backlog")
+
+    async def get_health_history(
+        self,
+        model: Optional[str] = None,
+        status_filter: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+    ) -> dict:
+        """Historical health check results (`GET /health/history`).
+
+        `status_filter` accepts upstream values (`healthy` / `unhealthy`).
+        """
+        params = {
+            k: v
+            for k, v in {
+                "model": model,
+                "status_filter": status_filter,
+                "limit": limit,
+                "offset": offset,
+            }.items()
+            if v is not None
+        }
+        return await self._request("GET", "/health/history", params=params or None)
+
+    async def get_health_latest(self) -> dict:
+        """Latest health check snapshot (`GET /health/latest`)."""
+        return await self._request("GET", "/health/latest")
+
+    async def test_model_connection(
+        self,
+        litellm_params: dict,
+        mode: Optional[str] = None,
+        model_info: Optional[dict] = None,
+    ) -> dict:
+        """Test a candidate deployment connection (`POST /health/test_connection`).
+
+        `litellm_params` is the provider routing dict (same shape as `add_model`).
+        `mode` is the upstream test mode (e.g. `chat`, `embedding`, `completion`).
+        `model_info` is optional deployment metadata for the probe.
+        """
+        body: dict[str, Any] = {"litellm_params": litellm_params}
+        if mode is not None:
+            body["mode"] = mode
+        if model_info is not None:
+            body["model_info"] = model_info
+        return await self._request("POST", "/health/test_connection", json=body)

--- a/src/server.py
+++ b/src/server.py
@@ -130,6 +130,56 @@ RESPONSE_FIELDS: dict[str, dict[str, Optional[list[str]]]] = {
         ],
         "full": None,
     },
+    "budget": {
+        "minimal": ["budget_id"],
+        "standard": [
+            "budget_id",
+            "max_budget",
+            "soft_budget",
+            "budget_duration",
+            "tpm_limit",
+            "rpm_limit",
+            "model_max_budget",
+            "budget_reset_at",
+        ],
+        "full": None,
+    },
+    "spend_record": {
+        "minimal": ["request_id", "model"],
+        "standard": [
+            "request_id",
+            "call_type",
+            "api_key",
+            "user",
+            "team_id",
+            "model",
+            "total_tokens",
+            "spend",
+            "startTime",
+            "endTime",
+        ],
+        "full": None,
+    },
+    "chat_completion": {
+        "minimal": ["id", "model"],
+        "standard": ["id", "object", "created", "model", "choices", "usage"],
+        "full": None,
+    },
+    "embedding": {
+        "minimal": ["model"],
+        "standard": ["object", "model", "data", "usage"],
+        "full": None,
+    },
+    "health": {
+        "minimal": ["healthy_count", "unhealthy_count"],
+        "standard": [
+            "healthy_count",
+            "unhealthy_count",
+            "healthy_endpoints",
+            "unhealthy_endpoints",
+        ],
+        "full": None,
+    },
 }
 
 VALID_VERBOSITY_LEVELS = {"minimal", "standard", "full"}
@@ -1429,6 +1479,355 @@ async def update_user_access_group(
 async def delete_user_access_group(access_group_id: str) -> dict:
     """Delete a unified user access group (`DELETE /v1/unified_access_group/{id}`)."""
     return await get_client().delete_user_access_group(access_group_id)
+
+
+# ── Budget tools ──
+
+
+@mcp.tool()
+async def list_budgets(verbosity: str = "standard") -> Any:
+    """List configured budgets (`GET /budget/list`).
+
+    Args:
+        verbosity: 'minimal' / 'standard' / 'full'.
+    """
+    payload = await get_client().list_budgets()
+    return _filter_response(payload, "budget", verbosity)
+
+
+@mcp.tool()
+async def get_budget_info(budgets: list[str], verbosity: str = "standard") -> Any:
+    """Get info about one or more budgets (`POST /budget/info`).
+
+    Despite the GET-shaped name, the upstream uses POST with a body
+    `{"budgets": [...]}` — this is a batch lookup, not a per-id GET.
+
+    Args:
+        budgets: list of budget ids/names to fetch.
+        verbosity: 'minimal' / 'standard' / 'full'.
+    """
+    payload = await get_client().get_budget_info(budgets)
+    return _filter_response(payload, "budget", verbosity)
+
+
+@mcp.tool()
+async def create_budget(
+    budget_id: Optional[str] = None,
+    max_budget: Optional[float] = None,
+    soft_budget: Optional[float] = None,
+    max_parallel_requests: Optional[int] = None,
+    tpm_limit: Optional[int] = None,
+    rpm_limit: Optional[int] = None,
+    budget_duration: Optional[str] = None,
+    model_max_budget: Optional[dict] = None,
+    budget_reset_at: Optional[str] = None,
+    extras: Optional[dict] = None,
+) -> dict:
+    """Create a budget (`POST /budget/new`).
+
+    All fields optional per upstream `BudgetNewRequest`. Use `extras` for any
+    field not surfaced as a named arg.
+
+    Args:
+        budget_id: optional explicit id (upstream auto-generates if omitted).
+        max_budget: hard spend cap (USD).
+        soft_budget: warning threshold below the hard cap.
+        budget_duration: reset window (e.g. `30d`).
+        model_max_budget: per-model caps, e.g. `{"gpt-4o": {"budget_limit": 10.0}}`.
+    """
+    return await get_client().create_budget(
+        budget_id,
+        max_budget,
+        soft_budget,
+        max_parallel_requests,
+        tpm_limit,
+        rpm_limit,
+        budget_duration,
+        model_max_budget,
+        budget_reset_at,
+        extras,
+    )
+
+
+@mcp.tool()
+async def update_budget(
+    budget_id: str,
+    max_budget: Optional[float] = None,
+    soft_budget: Optional[float] = None,
+    max_parallel_requests: Optional[int] = None,
+    tpm_limit: Optional[int] = None,
+    rpm_limit: Optional[int] = None,
+    budget_duration: Optional[str] = None,
+    model_max_budget: Optional[dict] = None,
+    budget_reset_at: Optional[str] = None,
+    extras: Optional[dict] = None,
+) -> dict:
+    """Update a budget (`POST /budget/update`).
+
+    Same `BudgetNewRequest` shape as create — `budget_id` identifies the row.
+    """
+    return await get_client().update_budget(
+        budget_id,
+        max_budget,
+        soft_budget,
+        max_parallel_requests,
+        tpm_limit,
+        rpm_limit,
+        budget_duration,
+        model_max_budget,
+        budget_reset_at,
+        extras,
+    )
+
+
+@mcp.tool()
+async def delete_budget(budget_id: str) -> dict:
+    """Delete a budget (`POST /budget/delete`).
+
+    Body is `{"id": <budget_id>}` per upstream `BudgetDeleteRequest`.
+    """
+    return await get_client().delete_budget(budget_id)
+
+
+@mcp.tool()
+async def get_budget_settings(budget_id: str) -> dict:
+    """Get effective budget settings (`GET /budget/settings`).
+
+    Args:
+        budget_id: required query param identifying the budget row.
+    """
+    return await get_client().get_budget_settings(budget_id)
+
+
+# ── Spend tools ──
+
+
+@mcp.tool()
+async def get_global_spend_report(
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    group_by: Optional[str] = None,
+    api_key: Optional[str] = None,
+    internal_user_id: Optional[str] = None,
+    team_id: Optional[str] = None,
+    customer_id: Optional[str] = None,
+) -> Any:
+    """Aggregated global spend report (`GET /global/spend/report`).
+
+    All filters are optional query params.
+
+    Args:
+        start_date / end_date: ISO `YYYY-MM-DD`.
+        group_by: upstream-defined dimension (`team`, `customer`, `api_key`, `model`).
+    """
+    return await get_client().get_global_spend_report(
+        start_date, end_date, group_by, api_key, internal_user_id, team_id, customer_id
+    )
+
+
+@mcp.tool()
+async def list_spend_logs(
+    api_key: Optional[str] = None,
+    user_id: Optional[str] = None,
+    request_id: Optional[str] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    summarize: Optional[bool] = None,
+    verbosity: str = "standard",
+) -> Any:
+    """List per-request spend logs (`GET /spend/logs`).
+
+    Args:
+        summarize: True to return aggregated rows.
+        verbosity: 'minimal' / 'standard' / 'full' — applied to the spend_record items.
+    """
+    payload = await get_client().list_spend_logs(
+        api_key, user_id, request_id, start_date, end_date, summarize
+    )
+    return _filter_response(payload, "spend_record", verbosity)
+
+
+@mcp.tool()
+async def list_spend_tags(
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+) -> Any:
+    """List distinct spend tags within a date window (`GET /spend/tags`)."""
+    return await get_client().list_spend_tags(start_date, end_date)
+
+
+@mcp.tool()
+async def calculate_spend(
+    model: Optional[str] = None,
+    messages: Optional[list[dict]] = None,
+    completion_response: Optional[dict] = None,
+) -> dict:
+    """Estimate spend for a request (`POST /spend/calculate`).
+
+    Either pass `model + messages` for a prospective estimate, or
+    `model + completion_response` for a retrospective re-cost.
+    """
+    return await get_client().calculate_spend(model, messages, completion_response)
+
+
+@mcp.tool()
+async def get_user_daily_activity(
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    model: Optional[str] = None,
+    api_key: Optional[str] = None,
+    user_id: Optional[str] = None,
+    page: Optional[int] = None,
+    page_size: Optional[int] = None,
+    timezone: Optional[str] = None,
+) -> dict:
+    """Per-user daily activity (`GET /user/daily/activity`).
+
+    Args:
+        start_date / end_date: ISO `YYYY-MM-DD` recommended.
+        timezone: IANA tz string (e.g. `Europe/Paris`) for daily-bucket alignment.
+    """
+    return await get_client().get_user_daily_activity(
+        start_date, end_date, model, api_key, user_id, page, page_size, timezone
+    )
+
+
+# ── Execution tools ──
+
+
+@mcp.tool()
+async def chat_completion(
+    model: str,
+    messages: list[dict],
+    body: Optional[dict] = None,
+    verbosity: str = "standard",
+) -> dict:
+    """Chat completion (`POST /v1/chat/completions`).
+
+    Synchronous only — `stream` is stripped from the body if passed. Use `body`
+    for any extra OpenAI / LiteLLM fields (temperature, max_tokens, tools, etc.).
+
+    Args:
+        model: model_name alias (e.g. `gpt-4o`, `claude-opus-4-7`).
+        messages: OpenAI-shaped message list.
+        body: optional dict of additional request fields.
+        verbosity: 'minimal' / 'standard' / 'full'.
+    """
+    payload = await get_client().chat_completion(model, messages, body)
+    return _filter_response(payload, "chat_completion", verbosity)
+
+
+@mcp.tool()
+async def completion(
+    model: str,
+    prompt: str,
+    body: Optional[dict] = None,
+    verbosity: str = "standard",
+) -> dict:
+    """Legacy text completion (`POST /v1/completions`).
+
+    Synchronous only — `stream` is stripped from the body if passed. The
+    upstream OpenAPI spec only documents a `model` query param for this
+    endpoint, but the implementation accepts the full OpenAI `/v1/completions`
+    body — we send `model` in both query and body.
+
+    Args:
+        model: model_name alias.
+        prompt: text prompt.
+        body: optional dict of additional fields (max_tokens, temperature, etc.).
+        verbosity: 'minimal' / 'standard' / 'full'.
+    """
+    payload = await get_client().completion(model, prompt, body)
+    return _filter_response(payload, "chat_completion", verbosity)
+
+
+@mcp.tool()
+async def embed(
+    model: str,
+    input: list[str],
+    body: Optional[dict] = None,
+    verbosity: str = "standard",
+) -> dict:
+    """Generate embeddings (`POST /v1/embeddings`).
+
+    Args:
+        model: embedding model_name alias.
+        input: list of input strings (wrap a single string as `[text]`).
+        body: optional dict of additional fields (`dimensions`, `encoding_format`, ...).
+        verbosity: 'minimal' / 'standard' / 'full'.
+    """
+    payload = await get_client().embed(model, input, body)
+    return _filter_response(payload, "embedding", verbosity)
+
+
+# ── Health tools ──
+
+
+@mcp.tool()
+async def check_health(
+    model: Optional[str] = None,
+    model_id: Optional[str] = None,
+    verbosity: str = "standard",
+) -> dict:
+    """Run upstream health checks against deployments (`GET /health`).
+
+    Args:
+        model: optional model_name alias to narrow the probe.
+        model_id: optional litellm internal id to narrow the probe.
+        verbosity: 'minimal' / 'standard' / 'full'.
+    """
+    payload = await get_client().check_health(model, model_id)
+    return _filter_response(payload, "health", verbosity)
+
+
+@mcp.tool()
+async def check_health_backlog() -> dict:
+    """Get health-check queue backlog (`GET /health/backlog`)."""
+    return await get_client().check_health_backlog()
+
+
+@mcp.tool()
+async def get_health_history(
+    model: Optional[str] = None,
+    status_filter: Optional[str] = None,
+    limit: Optional[int] = None,
+    offset: Optional[int] = None,
+) -> dict:
+    """Historical health check results (`GET /health/history`).
+
+    Args:
+        status_filter: upstream status (`healthy` / `unhealthy`).
+    """
+    return await get_client().get_health_history(model, status_filter, limit, offset)
+
+
+@mcp.tool()
+async def get_health_latest(verbosity: str = "standard") -> dict:
+    """Latest health check snapshot (`GET /health/latest`).
+
+    Args:
+        verbosity: 'minimal' / 'standard' / 'full'.
+    """
+    payload = await get_client().get_health_latest()
+    return _filter_response(payload, "health", verbosity)
+
+
+@mcp.tool()
+async def test_model_connection(
+    litellm_params: dict,
+    mode: Optional[str] = None,
+    model_info: Optional[dict] = None,
+) -> dict:
+    """Test a candidate deployment connection (`POST /health/test_connection`).
+
+    Useful for validating provider credentials before calling `add_model`.
+
+    Args:
+        litellm_params: provider routing dict (same shape as `add_model`).
+        mode: probe mode (`chat`, `embedding`, `completion`).
+        model_info: optional deployment metadata.
+    """
+    return await get_client().test_model_connection(litellm_params, mode, model_info)
 
 
 # ── Entrypoint ──

--- a/tests/smoke.py
+++ b/tests/smoke.py
@@ -286,6 +286,126 @@ async def run() -> int:
         else:
             results.append(("get_user_access_group", True, "skipped (no user access groups)"))
 
+        # Budget family (3 read ops — list, info-batch, settings)
+        budgets = await client.list_budgets()
+        results.append(("list_budgets", True, _summarize(budgets)))
+        first_budget_id = None
+        if isinstance(budgets, list) and budgets:
+            first_budget_id = budgets[0].get("budget_id") if isinstance(budgets[0], dict) else None
+        elif isinstance(budgets, dict):
+            data = budgets.get("data") or budgets.get("budgets") or []
+            if data:
+                first_budget_id = data[0].get("budget_id") if isinstance(data[0], dict) else None
+        if first_budget_id:
+            results.append(
+                await _step("get_budget_info", client.get_budget_info([first_budget_id]))
+            )
+            try:
+                payload = await client.get_budget_settings(first_budget_id)
+                results.append(("get_budget_settings", True, _summarize(payload)))
+            except LiteLLMAPIError as e:
+                # /budget/settings may 404 for budgets without explicit settings rows.
+                if e.status_code == 404:
+                    results.append(("get_budget_settings", True, "404 (no settings row)"))
+                else:
+                    results.append(("get_budget_settings", False, f"APIError {e.status_code}: {e}"))
+        else:
+            results.append(("get_budget_info", True, "skipped (no budgets)"))
+            results.append(("get_budget_settings", True, "skipped (no budgets)"))
+
+        # Spend family (4 read ops + 1 calculate)
+        # /global/spend/report is gated behind LiteLLM Enterprise — community
+        # tier returns 400 "You must be a LiteLLM Enterprise user". Wrapper is
+        # OK; mark as upstream-gated rather than a failure.
+        try:
+            payload = await client.get_global_spend_report(start_date=start_d, end_date=end_d)
+            results.append(("get_global_spend_report", True, _summarize(payload)))
+        except LiteLLMAPIError as e:
+            if e.status_code == 400 and "Enterprise" in str(e):
+                results.append(
+                    ("get_global_spend_report", True, "400 (Enterprise-gated, wrapper OK)")
+                )
+            else:
+                results.append(("get_global_spend_report", False, f"APIError {e.status_code}: {e}"))
+        results.append(
+            await _step(
+                "list_spend_logs", client.list_spend_logs(start_date=start_d, end_date=end_d)
+            )
+        )
+        results.append(
+            await _step(
+                "list_spend_tags", client.list_spend_tags(start_date=start_d, end_date=end_d)
+            )
+        )
+        results.append(
+            await _step(
+                "get_user_daily_activity",
+                client.get_user_daily_activity(
+                    start_date=start_d, end_date=end_d, page=1, page_size=5
+                ),
+            )
+        )
+        results.append(
+            await _step(
+                "calculate_spend",
+                client.calculate_spend(
+                    model="tora-no-think",
+                    messages=[{"role": "user", "content": "hi"}],
+                ),
+            )
+        )
+
+        # Health family (4 read ops, test_connection skipped — write-shaped)
+        results.append(await _step("check_health_backlog", client.check_health_backlog()))
+        results.append(await _step("get_health_latest", client.get_health_latest()))
+        results.append(await _step("get_health_history", client.get_health_history(limit=5)))
+        # /health probes every router-registered deployment — can take 30+s.
+        # Narrow to a single small local model.
+        results.append(await _step("check_health", client.check_health(model="tora-no-think")))
+
+        # Execution family (3 paths) — these spend real (small) tokens against
+        # local vLLM deployments. Skip via SMOKE_SKIP_EXEC=1 if needed.
+        if os.environ.get("SMOKE_SKIP_EXEC"):
+            results.append(("chat_completion", True, "skipped (SMOKE_SKIP_EXEC)"))
+            results.append(("completion", True, "skipped (SMOKE_SKIP_EXEC)"))
+            results.append(("embed", True, "skipped (SMOKE_SKIP_EXEC)"))
+        else:
+            try:
+                cc = await client.chat_completion(
+                    model="tora-no-think",
+                    messages=[{"role": "user", "content": "Reply with: ok"}],
+                    body={"max_tokens": 5, "temperature": 0.0},
+                )
+                results.append(("chat_completion", True, _summarize(cc)))
+            except LiteLLMAPIError as e:
+                results.append(("chat_completion", False, f"APIError {e.status_code}: {e}"))
+
+            # Legacy /v1/completions: many chat-only models 400 here. Mark
+            # 400/404/422 as "expected" since no legacy-text deployment exists.
+            try:
+                comp = await client.completion(
+                    model="tora-no-think",
+                    prompt="The capital of France is",
+                    body={"max_tokens": 3, "temperature": 0.0},
+                )
+                results.append(("completion", True, _summarize(comp)))
+            except LiteLLMAPIError as e:
+                if e.status_code in {400, 404, 422}:
+                    results.append(
+                        ("completion", True, f"{e.status_code} (no legacy-text deployment)")
+                    )
+                else:
+                    results.append(("completion", False, f"APIError {e.status_code}: {e}"))
+
+            try:
+                emb = await client.embed(
+                    model="qwen/qwen3-embedding-0.6b",
+                    input=["smoke test"],
+                )
+                results.append(("embed", True, _summarize(emb)))
+            except LiteLLMAPIError as e:
+                results.append(("embed", False, f"APIError {e.status_code}: {e}"))
+
     finally:
         await client.close()
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -913,6 +913,300 @@ class TestDeleteUserAccessGroup:
         mock_client.delete_user_access_group.assert_awaited_once_with("ag-1")
 
 
+# ── Budget tools ──
+
+
+class TestListBudgets:
+    @pytest.mark.asyncio
+    async def test_minimal_strips_fields(self, mock_client):
+        mock_client.list_budgets.return_value = [
+            {"budget_id": "b-1", "max_budget": 100.0, "tpm_limit": 1000},
+        ]
+        result = await src.server.list_budgets("minimal")
+        assert result == [{"budget_id": "b-1"}]
+
+
+class TestGetBudgetInfo:
+    @pytest.mark.asyncio
+    async def test_passes_list(self, mock_client):
+        mock_client.get_budget_info.return_value = [{"budget_id": "b-1", "max_budget": 50.0}]
+        result = await src.server.get_budget_info(["b-1"], "standard")
+        mock_client.get_budget_info.assert_awaited_once_with(["b-1"])
+        assert result[0]["budget_id"] == "b-1"
+
+
+class TestCreateBudget:
+    @pytest.mark.asyncio
+    async def test_all_fields_optional(self, mock_client):
+        mock_client.create_budget.return_value = {"budget_id": "b-1"}
+        await src.server.create_budget(max_budget=100.0, budget_duration="30d")
+        mock_client.create_budget.assert_awaited_once_with(
+            None, 100.0, None, None, None, None, "30d", None, None, None
+        )
+
+
+class TestUpdateBudget:
+    @pytest.mark.asyncio
+    async def test_required_id(self, mock_client):
+        mock_client.update_budget.return_value = {"ok": True}
+        await src.server.update_budget("b-1", max_budget=200.0)
+        mock_client.update_budget.assert_awaited_once_with(
+            "b-1", 200.0, None, None, None, None, None, None, None, None
+        )
+
+
+class TestDeleteBudget:
+    @pytest.mark.asyncio
+    async def test_passes_id(self, mock_client):
+        mock_client.delete_budget.return_value = {"deleted": True}
+        await src.server.delete_budget("b-1")
+        mock_client.delete_budget.assert_awaited_once_with("b-1")
+
+
+class TestGetBudgetSettings:
+    @pytest.mark.asyncio
+    async def test_passes_id(self, mock_client):
+        mock_client.get_budget_settings.return_value = {"budget_id": "b-1"}
+        await src.server.get_budget_settings("b-1")
+        mock_client.get_budget_settings.assert_awaited_once_with("b-1")
+
+
+# ── Spend tools ──
+
+
+class TestGetGlobalSpendReport:
+    @pytest.mark.asyncio
+    async def test_filters_passed(self, mock_client):
+        mock_client.get_global_spend_report.return_value = []
+        await src.server.get_global_spend_report(
+            start_date="2026-04-01", end_date="2026-04-27", group_by="team"
+        )
+        mock_client.get_global_spend_report.assert_awaited_once_with(
+            "2026-04-01", "2026-04-27", "team", None, None, None, None
+        )
+
+
+class TestListSpendLogs:
+    @pytest.mark.asyncio
+    async def test_filters_to_spend_record(self, mock_client):
+        mock_client.list_spend_logs.return_value = [
+            {
+                "request_id": "r-1",
+                "model": "gpt-4o",
+                "spend": 0.012,
+                "total_tokens": 100,
+                "extra": "drop",
+            }
+        ]
+        result = await src.server.list_spend_logs(api_key="sk-x", verbosity="standard")
+        assert result == [
+            {"request_id": "r-1", "model": "gpt-4o", "spend": 0.012, "total_tokens": 100}
+        ]
+        mock_client.list_spend_logs.assert_awaited_once_with("sk-x", None, None, None, None, None)
+
+    @pytest.mark.asyncio
+    async def test_minimal(self, mock_client):
+        mock_client.list_spend_logs.return_value = [
+            {"request_id": "r-1", "model": "gpt-4o", "spend": 0.012}
+        ]
+        result = await src.server.list_spend_logs(verbosity="minimal")
+        assert result == [{"request_id": "r-1", "model": "gpt-4o"}]
+
+
+class TestListSpendTags:
+    @pytest.mark.asyncio
+    async def test_passthrough(self, mock_client):
+        mock_client.list_spend_tags.return_value = ["tag-a", "tag-b"]
+        result = await src.server.list_spend_tags()
+        assert result == ["tag-a", "tag-b"]
+
+
+class TestCalculateSpend:
+    @pytest.mark.asyncio
+    async def test_prospective(self, mock_client):
+        mock_client.calculate_spend.return_value = {"cost": 0.0023}
+        await src.server.calculate_spend(
+            model="gpt-4o", messages=[{"role": "user", "content": "hi"}]
+        )
+        mock_client.calculate_spend.assert_awaited_once_with(
+            "gpt-4o", [{"role": "user", "content": "hi"}], None
+        )
+
+    @pytest.mark.asyncio
+    async def test_retrospective(self, mock_client):
+        mock_client.calculate_spend.return_value = {"cost": 0.0042}
+        resp = {"choices": [{"message": {"content": "hello"}}]}
+        await src.server.calculate_spend(model="gpt-4o", completion_response=resp)
+        mock_client.calculate_spend.assert_awaited_once_with("gpt-4o", None, resp)
+
+
+class TestGetUserDailyActivity:
+    @pytest.mark.asyncio
+    async def test_filters_passed(self, mock_client):
+        mock_client.get_user_daily_activity.return_value = {"results": []}
+        await src.server.get_user_daily_activity(
+            start_date="2026-04-01", end_date="2026-04-27", user_id="u-1", timezone="Europe/Paris"
+        )
+        mock_client.get_user_daily_activity.assert_awaited_once_with(
+            "2026-04-01", "2026-04-27", None, None, "u-1", None, None, "Europe/Paris"
+        )
+
+
+# ── Execution tools ──
+
+
+class TestChatCompletion:
+    @pytest.mark.asyncio
+    async def test_basic(self, mock_client):
+        raw = {
+            "id": "cmpl-1",
+            "object": "chat.completion",
+            "created": 1,
+            "model": "gpt-4o",
+            "choices": [{"message": {"role": "assistant", "content": "hi"}}],
+            "usage": {"total_tokens": 5},
+            "system_fingerprint": "fp_drop_me",
+        }
+        mock_client.chat_completion.return_value = raw
+        result = await src.server.chat_completion(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "hello"}],
+            verbosity="standard",
+        )
+        assert "system_fingerprint" not in result
+        assert result["id"] == "cmpl-1"
+        assert result["choices"][0]["message"]["content"] == "hi"
+        mock_client.chat_completion.assert_awaited_once_with(
+            "gpt-4o", [{"role": "user", "content": "hello"}], None
+        )
+
+    @pytest.mark.asyncio
+    async def test_minimal_strips_to_id_model(self, mock_client):
+        mock_client.chat_completion.return_value = {
+            "id": "cmpl-1",
+            "model": "gpt-4o",
+            "choices": [],
+            "usage": {},
+        }
+        result = await src.server.chat_completion(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "hi"}],
+            verbosity="minimal",
+        )
+        assert result == {"id": "cmpl-1", "model": "gpt-4o"}
+
+    @pytest.mark.asyncio
+    async def test_passes_extra_body(self, mock_client):
+        mock_client.chat_completion.return_value = {"id": "cmpl-1", "model": "x"}
+        await src.server.chat_completion(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "hi"}],
+            body={"temperature": 0.0, "max_tokens": 64},
+        )
+        mock_client.chat_completion.assert_awaited_once_with(
+            "gpt-4o",
+            [{"role": "user", "content": "hi"}],
+            {"temperature": 0.0, "max_tokens": 64},
+        )
+
+
+class TestCompletion:
+    @pytest.mark.asyncio
+    async def test_basic(self, mock_client):
+        mock_client.completion.return_value = {"id": "cmpl-2", "model": "gpt-3.5-turbo-instruct"}
+        await src.server.completion(model="gpt-3.5-turbo-instruct", prompt="The sky is")
+        mock_client.completion.assert_awaited_once_with(
+            "gpt-3.5-turbo-instruct", "The sky is", None
+        )
+
+
+class TestEmbed:
+    @pytest.mark.asyncio
+    async def test_basic(self, mock_client):
+        mock_client.embed.return_value = {
+            "object": "list",
+            "model": "text-embedding-3-small",
+            "data": [{"embedding": [0.0, 0.1]}],
+            "usage": {"total_tokens": 2},
+        }
+        result = await src.server.embed(
+            model="text-embedding-3-small", input=["hi", "there"], verbosity="standard"
+        )
+        assert result["model"] == "text-embedding-3-small"
+        assert len(result["data"]) == 1
+        mock_client.embed.assert_awaited_once_with("text-embedding-3-small", ["hi", "there"], None)
+
+
+# ── Health tools ──
+
+
+class TestCheckHealth:
+    @pytest.mark.asyncio
+    async def test_no_filter(self, mock_client):
+        mock_client.check_health.return_value = {
+            "healthy_count": 3,
+            "unhealthy_count": 0,
+            "healthy_endpoints": [{"model": "gpt-4o"}],
+            "unhealthy_endpoints": [],
+            "extra": "drop",
+        }
+        result = await src.server.check_health(verbosity="standard")
+        assert "extra" not in result
+        assert result["healthy_count"] == 3
+        mock_client.check_health.assert_awaited_once_with(None, None)
+
+    @pytest.mark.asyncio
+    async def test_with_model_filter(self, mock_client):
+        mock_client.check_health.return_value = {"healthy_count": 1, "unhealthy_count": 0}
+        await src.server.check_health(model="gpt-4o")
+        mock_client.check_health.assert_awaited_once_with("gpt-4o", None)
+
+
+class TestCheckHealthBacklog:
+    @pytest.mark.asyncio
+    async def test_passthrough(self, mock_client):
+        mock_client.check_health_backlog.return_value = {"queue_depth": 0}
+        result = await src.server.check_health_backlog()
+        assert result == {"queue_depth": 0}
+
+
+class TestGetHealthHistory:
+    @pytest.mark.asyncio
+    async def test_filters_passed(self, mock_client):
+        mock_client.get_health_history.return_value = []
+        await src.server.get_health_history(
+            model="gpt-4o", status_filter="unhealthy", limit=50, offset=0
+        )
+        mock_client.get_health_history.assert_awaited_once_with("gpt-4o", "unhealthy", 50, 0)
+
+
+class TestGetHealthLatest:
+    @pytest.mark.asyncio
+    async def test_filters_to_health(self, mock_client):
+        mock_client.get_health_latest.return_value = {
+            "healthy_count": 5,
+            "unhealthy_count": 1,
+            "healthy_endpoints": [],
+            "unhealthy_endpoints": [],
+            "internal_state": "drop",
+        }
+        result = await src.server.get_health_latest("standard")
+        assert "internal_state" not in result
+
+
+class TestTestModelConnection:
+    @pytest.mark.asyncio
+    async def test_required_litellm_params(self, mock_client):
+        mock_client.test_model_connection.return_value = {"status": "ok"}
+        await src.server.test_model_connection(
+            litellm_params={"model": "openai/gpt-4o", "api_key": "sk-x"},
+            mode="chat",
+        )
+        mock_client.test_model_connection.assert_awaited_once_with(
+            {"model": "openai/gpt-4o", "api_key": "sk-x"}, "chat", None
+        )
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client

--- a/uv.lock
+++ b/uv.lock
@@ -546,7 +546,7 @@ wheels = [
 
 [[package]]
 name = "litellm-mcp"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

US [#596](https://taiga.tetra-ai.fr/project/tetra/us/596) (split from #536 alongside identity #536a) — Spend, Execution & Health.

Adds 19 tools across 4 families:

- **Budgets (6):** `list_budgets`, `get_budget_info` (batch), `create_budget`, `update_budget`, `delete_budget`, `get_budget_settings`.
- **Spend (5):** `get_global_spend_report` (Enterprise-gated), `list_spend_logs`, `list_spend_tags`, `calculate_spend` (prospective + retrospective), `get_user_daily_activity`.
- **Execution (3):** `chat_completion`, `completion`, `embed` — synchronous (stream stripped).
- **Health (5):** `check_health`, `check_health_backlog`, `get_health_history`, `get_health_latest`, `test_model_connection`.

Plus 5 new `RESPONSE_FIELDS` shapes (`budget`, `spend_record`, `chat_completion`, `embedding`, `health`).

Server tool count: **64 → 83**.

## Test plan

- [x] Unit tests (`uv run pytest`) — **117 passing** (24 new, 93 pre-existing).
- [x] Live smoke (`uv run python tests/smoke.py` against TETRA's LiteLLM proxy) — **42/42 passing**, including all 3 execution paths (chat/completion/embed against `tora-no-think` + `qwen/qwen3-embedding-0.6b`).
- [x] `ruff check` + `ruff format` clean.
- [x] CI green (let actions run).

## Upstream quirks documented in CLAUDE.md

- `POST /budget/info` is a batch GET (body `{"budgets": [...]}`).
- `POST /v1/completions` only declares a `model` query param in OpenAPI but accepts the full OpenAI body — wrapper sends `model` in both query and body.
- `GET /global/spend/report` is gated behind a LiteLLM Enterprise license — community tier returns HTTP 400.
- Execution tools strip `stream` from the body (synchronous in this slice).

## Out of scope (RFC scope-decision issues filed)

- #5 — `add_allowed_ip` / `delete_allowed_ip` (operator-level network ACL).
- #6 — `global_spend_reset` (destructive, no audit trail).
- #7 — `usage/ai/chat` (UI-internal, undocumented).
- #8 — `/health/liveness` / `/readiness` / `/license` / `/services` (LB-probe shaped, bundled).

## Release

semrel will cut `v1.3.0` on merge to `master`.