### PR TITLE
feat: MCP-Gateway tools (US #558 — 25 tools, semrel 1.x.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,17 +14,18 @@ MCP server for the LiteLLM proxy. Python 3.12, fastmcp (`mcp.server.fastmcp`), h
 ## Conventions
 
 - All read-shaped tools accept a `verbosity: str` argument (`minimal` / `standard` / `full`) and route through `_filter_response`. Write/admin tools generally don't filter (`update_model`, `add_model`, etc. return upstream as-is).
-- Add new resource shapes to `RESPONSE_FIELDS` in `src/server.py`. Current shapes: `model`, `access_group`, `credential`, `key`, `public_hub`, `user`, `customer`, `organization`, `project`, `user_access_group`, `budget`, `spend_record`, `chat_completion`, `embedding`, `health`. The `credential.standard` shape intentionally drops `credential_values` to avoid leaking secrets — use `full` to inspect.
+- Add new resource shapes to `RESPONSE_FIELDS` in `src/server.py`. Current shapes: `model`, `access_group`, `credential`, `key`, `public_hub`, `user`, `customer`, `organization`, `project`, `user_access_group`, `budget`, `spend_record`, `chat_completion`, `embedding`, `health`, `mcp_server`, `mcp_tool`, `mcp_submission`, `mcp_credential`, `mcp_health`. The `credential.standard` and `mcp_credential.standard` shapes intentionally drop credential values to avoid leaking secrets — use `full` to inspect.
 - New endpoints go on `LiteLLMClient` first, then a thin `@mcp.tool()` wrapper in `server.py`.
 - For body schemas with many optional fields (`GenerateKeyRequest`, `UpdateKeyRequest`, `RegenerateKeyRequest`, `NewUserRequest`, `NewCustomerRequest`, `NewOrganizationRequest`, `NewProjectRequest`), expose ~12 common fields as named args and accept the long tail through an `extras: Optional[dict]` argument (merged into the body via `_build_body`/`_build_key_body`).
 - Keep transport agnostic: never call `print` / write to stdout in stdio mode.
 
-## Current scope (US #534 + #535 + #536 + #596)
+## Current scope (US #534 + #535 + #536 + #596 + #558)
 
 - **#534 (v1.0.0):** foundation, `list_models`.
 - **#535 (v1.1.0):** 32 admin tools — Models (5), Model Hub (5), Access Groups (5), Credentials (6), Keys (11). All wrapped with unit tests against `AsyncMock(LiteLLMClient)`.
 - **#536 (v1.2.0):** 31 identity tools — Internal Users (5), Customers (7), Organizations (9, incl. member CRUD), Projects (5), Unified User Access Groups (5).
-- **#596:** 19 tools — Budgets (6), Spend (5), Execution (3 — chat/completion/embed, synchronous), Health (5). Same test/smoke conventions.
+- **#596 (v1.3.0):** 19 tools — Budgets (6), Spend (5), Execution (3 — chat/completion/embed, synchronous), Health (5).
+- **#558:** 25 MCP-Gateway tools — Server CRUD (6), Submissions (3), Health (1), Tool discovery & invocation (4), Discovery/registry/hub (6), User credentials (4), Utility (1). Lets the proxy broker upstream HTTP-transport MCP servers and list/invoke their tools.
 
 ### Upstream quirks
 
@@ -37,6 +38,10 @@ MCP server for the LiteLLM proxy. Python 3.12, fastmcp (`mcp.server.fastmcp`), h
 - `POST /v1/completions` only documents a `model` query param in the OpenAPI spec but accepts the full OpenAI-shaped body. The wrapper sends `model` in both query and body.
 - `GET /global/spend/report` is gated behind a LiteLLM Enterprise license — community-tier proxies return HTTP 400 "You must be a LiteLLM Enterprise user". The wrapper passes the call through unchanged.
 - Execution tools (`chat_completion` / `completion` / `embed`) are synchronous; `stream` is stripped from the body. Streaming would require a different MCP transport contract — revisit as a follow-on if needed.
+- `PUT /v1/mcp/server` carries `server_id` in the body (per `UpdateMCPServerRequest`), not the path — opposite convention from the GET/DELETE variants.
+- `POST /mcp-rest/tools/call` has no documented body schema in OpenAPI but expects `{"server_id": ..., "name": ..., "arguments": {...}}` per the MCP `tools/call` shape.
+- MCP tool invocation (`call_mcp_tool`) does **not** rely on the registered server's `allow_all_keys` flag alone — there is a per-user MCP-access check upstream that returns "User not allowed to call this tool" even for the master key, unless the calling user is a member of the server's `mcp_access_groups`. Wrapper sends a correct request; granting access is a deployment concern (assign the calling user to an MCP access group, or attach `mcp_servers=[<id>]` to the calling key).
+- `GET /v1/mcp/registry.json` is optional upstream — older / minimal proxy configs return 404. Wrapper returns the upstream payload as-is.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@ Foundation (US #534) shipped `list_models`. Admin slice (US #535) added 32 tools
 covering models, model hub, model access groups, credentials, and virtual keys.
 Identity slice (US #536) added 31 tools covering internal users, customers,
 organizations (with member management), projects, and unified user access
-groups. Spend/execution/health slice (US #596) adds 19 tools covering budgets,
+groups. Spend/execution/health slice (US #596) added 19 tools covering budgets,
 spend reporting, the three core execution verbs (chat / completion / embed),
-and admin health probes. Subsequent slices add governance and passthrough
-(#538) and the MCP-of-MCPs gateway (#558).
+and admin health probes. MCP-Gateway slice (US #558) adds 25 tools that let
+the LiteLLM proxy act as an MCP-of-MCPs: register upstream HTTP-transport MCP
+servers and list / invoke their tools through the proxy. Governance and
+passthrough (#538) is the remaining deferred slice.
 
 ## Setup
 
@@ -246,6 +248,62 @@ via the `body: dict` argument.
 | `get_health_history` | `GET /health/history` |
 | `get_health_latest` | `GET /health/latest` |
 | `test_model_connection` | `POST /health/test_connection` |
+
+### MCP Gateway — Server CRUD (6)
+
+| Tool | Endpoint |
+|------|----------|
+| `list_mcp_servers` | `GET /v1/mcp/server` |
+| `get_mcp_server` | `GET /v1/mcp/server/{server_id}` |
+| `add_mcp_server` | `POST /v1/mcp/server` (admin path, approved) |
+| `update_mcp_server` | `PUT /v1/mcp/server` (server_id in body) |
+| `delete_mcp_server` | `DELETE /v1/mcp/server/{server_id}` |
+| `register_mcp_server` | `POST /v1/mcp/server/register` (user path, pending review) |
+
+### MCP Gateway — Submissions (3)
+
+| Tool | Endpoint |
+|------|----------|
+| `list_mcp_server_submissions` | `GET /v1/mcp/server/submissions` |
+| `approve_mcp_server_submission` | `PUT /v1/mcp/server/{id}/approve` |
+| `reject_mcp_server_submission` | `PUT /v1/mcp/server/{id}/reject` |
+
+### MCP Gateway — Tool Discovery & Invocation (4) + Health (1)
+
+| Tool | Endpoint |
+|------|----------|
+| `check_mcp_servers_health` | `GET /v1/mcp/server/health` |
+| `list_mcp_tools` | `GET /v1/mcp/tools` |
+| `list_mcp_tools_rest` | `GET /mcp-rest/tools/list` |
+| `call_mcp_tool` | `POST /mcp-rest/tools/call` |
+| `test_mcp_connection` | `POST /mcp-rest/test/connection` |
+
+`call_mcp_tool` body shape: `{"server_id": ..., "name": ..., "arguments": {...}}`. Returns the provider-shaped MCP envelope (`{"content": [...], "isError": bool}`) unmodified.
+
+### MCP Gateway — Discovery / Registry / Hub (6)
+
+| Tool | Endpoint |
+|------|----------|
+| `discover_mcp_servers` | `GET /v1/mcp/discover` |
+| `get_mcp_openapi_registry` | `GET /v1/mcp/openapi-registry` |
+| `get_mcp_registry` | `GET /v1/mcp/registry.json` |
+| `list_mcp_access_groups` | `GET /v1/mcp/access_groups` |
+| `make_mcp_servers_public` | `POST /v1/mcp/make_public` |
+| `get_public_mcp_hub` | `GET /public/mcp_hub` |
+
+### MCP Gateway — User Credentials (4) + Utility (1)
+
+| Tool | Endpoint |
+|------|----------|
+| `list_mcp_user_credentials` | `GET /v1/mcp/user-credentials` |
+| `set_mcp_user_credential(server_id, credential, oauth: bool)` | `POST /v1/mcp/server/{id}/user-credential` ∣ `POST .../oauth-user-credential` |
+| `delete_mcp_user_credential(server_id, oauth: bool)` | `DELETE /v1/mcp/server/{id}/user-credential` ∣ `DELETE .../oauth-user-credential` |
+| `get_mcp_oauth_user_credential_status` | `GET /v1/mcp/server/{id}/oauth-user-credential/status` |
+| `get_mcp_client_ip` | `GET /v1/mcp/network/client-ip` |
+
+The `oauth: bool` discriminator on `set_mcp_user_credential` and `delete_mcp_user_credential` compresses the OAuth + non-OAuth endpoints into one tool each. Non-OAuth body: `{"credential": ..., "save": ...}`. OAuth body: `{"access_token": ..., "refresh_token": ..., "expires_in": ..., "scopes": [...]}`.
+
+`add_mcp_server` / `update_mcp_server` / `register_mcp_server` / `test_mcp_connection` accept an `extras: dict` argument for the long tail of `NewMCPServerRequest` fields not surfaced as named args (~20 less common fields like `static_headers`, `oauth2_flow`, `tool_name_to_display_name`, `allow_all_keys`).
 
 ## Development
 

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -1588,3 +1588,386 @@ class LiteLLMClient:
         if model_info is not None:
             body["model_info"] = model_info
         return await self._request("POST", "/health/test_connection", json=body)
+
+    # ── MCP Gateway operations ──
+    #
+    # The LiteLLM proxy can act as an MCP-of-MCPs: register upstream HTTP-transport
+    # MCP servers and broker tool listing / invocation through the proxy. These
+    # tools wrap the `/v1/mcp/*` and `/mcp-rest/*` admin surfaces.
+
+    @staticmethod
+    def _build_mcp_server_body(
+        server_id: Optional[str],
+        server_name: Optional[str],
+        alias: Optional[str],
+        description: Optional[str],
+        transport: Optional[str],
+        url: Optional[str],
+        auth_type: Optional[str],
+        spec_path: Optional[str],
+        mcp_info: Optional[dict],
+        mcp_access_groups: Optional[list[str]],
+        allowed_tools: Optional[list[str]],
+        credentials: Optional[dict],
+        extras: Optional[dict],
+    ) -> dict[str, Any]:
+        """Build a NewMCPServerRequest / UpdateMCPServerRequest body."""
+        body = {
+            k: v
+            for k, v in {
+                "server_id": server_id,
+                "server_name": server_name,
+                "alias": alias,
+                "description": description,
+                "transport": transport,
+                "url": url,
+                "auth_type": auth_type,
+                "spec_path": spec_path,
+                "mcp_info": mcp_info,
+                "mcp_access_groups": mcp_access_groups,
+                "allowed_tools": allowed_tools,
+                "credentials": credentials,
+            }.items()
+            if v is not None
+        }
+        if extras:
+            body.update(extras)
+        return body
+
+    async def list_mcp_servers(self, team_id: Optional[str] = None) -> Any:
+        """List registered upstream MCP servers (`GET /v1/mcp/server`).
+
+        `team_id` optionally narrows to servers visible to a single team.
+        """
+        params = {"team_id": team_id} if team_id else None
+        return await self._request("GET", "/v1/mcp/server", params=params)
+
+    async def get_mcp_server(self, server_id: str) -> dict:
+        """Get a single MCP server by id (`GET /v1/mcp/server/{server_id}`)."""
+        return await self._request("GET", f"/v1/mcp/server/{server_id}")
+
+    async def add_mcp_server(
+        self,
+        transport: str,
+        server_name: Optional[str] = None,
+        alias: Optional[str] = None,
+        description: Optional[str] = None,
+        url: Optional[str] = None,
+        auth_type: Optional[str] = None,
+        spec_path: Optional[str] = None,
+        mcp_info: Optional[dict] = None,
+        mcp_access_groups: Optional[list[str]] = None,
+        allowed_tools: Optional[list[str]] = None,
+        credentials: Optional[dict] = None,
+        server_id: Optional[str] = None,
+        extras: Optional[dict] = None,
+    ) -> dict:
+        """Admin-register a new upstream MCP server (`POST /v1/mcp/server`).
+
+        `transport` is required (`http`, `sse`, `stdio`). For HTTP/SSE provide
+        `url`; for stdio you'd use upstream `command` / `args` / `env` fields
+        via `extras` (TETRA's gateway brokers HTTP-transport upstreams). Pass
+        any of the ~30 NewMCPServerRequest fields not surfaced as named args
+        through `extras` (e.g. `static_headers`, `extra_headers`,
+        `tool_name_to_display_name`, `oauth2_flow`).
+        """
+        body = self._build_mcp_server_body(
+            server_id,
+            server_name,
+            alias,
+            description,
+            transport,
+            url,
+            auth_type,
+            spec_path,
+            mcp_info,
+            mcp_access_groups,
+            allowed_tools,
+            credentials,
+            extras,
+        )
+        return await self._request("POST", "/v1/mcp/server", json=body)
+
+    async def update_mcp_server(
+        self,
+        server_id: str,
+        server_name: Optional[str] = None,
+        alias: Optional[str] = None,
+        description: Optional[str] = None,
+        transport: Optional[str] = None,
+        url: Optional[str] = None,
+        auth_type: Optional[str] = None,
+        spec_path: Optional[str] = None,
+        mcp_info: Optional[dict] = None,
+        mcp_access_groups: Optional[list[str]] = None,
+        allowed_tools: Optional[list[str]] = None,
+        credentials: Optional[dict] = None,
+        extras: Optional[dict] = None,
+    ) -> dict:
+        """Admin-update an MCP server (`PUT /v1/mcp/server`).
+
+        `server_id` identifies the row and is sent in the body, not the path —
+        UpdateMCPServerRequest treats it as required.
+        """
+        body = self._build_mcp_server_body(
+            server_id,
+            server_name,
+            alias,
+            description,
+            transport,
+            url,
+            auth_type,
+            spec_path,
+            mcp_info,
+            mcp_access_groups,
+            allowed_tools,
+            credentials,
+            extras,
+        )
+        return await self._request("PUT", "/v1/mcp/server", json=body)
+
+    async def delete_mcp_server(self, server_id: str) -> dict:
+        """Delete an MCP server (`DELETE /v1/mcp/server/{server_id}`)."""
+        return await self._request("DELETE", f"/v1/mcp/server/{server_id}")
+
+    async def register_mcp_server(
+        self,
+        transport: str,
+        server_name: Optional[str] = None,
+        alias: Optional[str] = None,
+        description: Optional[str] = None,
+        url: Optional[str] = None,
+        auth_type: Optional[str] = None,
+        spec_path: Optional[str] = None,
+        mcp_info: Optional[dict] = None,
+        mcp_access_groups: Optional[list[str]] = None,
+        allowed_tools: Optional[list[str]] = None,
+        credentials: Optional[dict] = None,
+        extras: Optional[dict] = None,
+    ) -> dict:
+        """Self-register an MCP server (`POST /v1/mcp/server/register`).
+
+        Distinct from `add_mcp_server`: `register` is the user-facing submission
+        path that creates a server in `pending` approval state, awaiting an
+        admin's `approve_mcp_server_submission`. `add_mcp_server` is the admin
+        path that creates servers in approved state directly.
+        """
+        body = self._build_mcp_server_body(
+            None,
+            server_name,
+            alias,
+            description,
+            transport,
+            url,
+            auth_type,
+            spec_path,
+            mcp_info,
+            mcp_access_groups,
+            allowed_tools,
+            credentials,
+            extras,
+        )
+        return await self._request("POST", "/v1/mcp/server/register", json=body)
+
+    async def list_mcp_server_submissions(self) -> Any:
+        """List pending MCP server submissions (`GET /v1/mcp/server/submissions`)."""
+        return await self._request("GET", "/v1/mcp/server/submissions")
+
+    async def approve_mcp_server_submission(self, server_id: str) -> dict:
+        """Approve a pending MCP submission (`PUT /v1/mcp/server/{id}/approve`)."""
+        return await self._request("PUT", f"/v1/mcp/server/{server_id}/approve")
+
+    async def reject_mcp_server_submission(
+        self, server_id: str, review_notes: Optional[str] = None
+    ) -> dict:
+        """Reject a pending MCP submission (`PUT /v1/mcp/server/{id}/reject`).
+
+        Optional `review_notes` is captured per upstream `RejectMCPServerRequest`.
+        """
+        body = {"review_notes": review_notes} if review_notes is not None else {}
+        return await self._request("PUT", f"/v1/mcp/server/{server_id}/reject", json=body)
+
+    async def check_mcp_servers_health(self, server_ids: Optional[str] = None) -> dict:
+        """Probe upstream MCP server health (`GET /v1/mcp/server/health`).
+
+        `server_ids` is an upstream-comma-separated string (not an array) to
+        narrow the probe to specific servers.
+        """
+        params = {"server_ids": server_ids} if server_ids else None
+        return await self._request("GET", "/v1/mcp/server/health", params=params)
+
+    async def list_mcp_tools(self) -> Any:
+        """List tools across all registered MCP servers (`GET /v1/mcp/tools`)."""
+        return await self._request("GET", "/v1/mcp/tools")
+
+    async def list_mcp_tools_rest(self, server_id: Optional[str] = None) -> Any:
+        """List tools (REST shape) for a registered MCP server (`GET /mcp-rest/tools/list`).
+
+        Lighter-weight than `list_mcp_tools`; per-server. `server_id` is a query
+        param.
+        """
+        params = {"server_id": server_id} if server_id else None
+        return await self._request("GET", "/mcp-rest/tools/list", params=params)
+
+    async def call_mcp_tool(
+        self,
+        server_id: str,
+        name: str,
+        arguments: Optional[dict] = None,
+    ) -> Any:
+        """Invoke a tool on a registered MCP server (`POST /mcp-rest/tools/call`).
+
+        Body shape: `{"server_id": ..., "name": ..., "arguments": {...}}`.
+        Upstream returns the provider-shaped tool response (typically the MCP
+        `tools/call` result envelope: `{"content": [...], "isError": bool}`).
+        """
+        body: dict[str, Any] = {"server_id": server_id, "name": name}
+        if arguments is not None:
+            body["arguments"] = arguments
+        return await self._request("POST", "/mcp-rest/tools/call", json=body)
+
+    async def test_mcp_connection(
+        self,
+        transport: str,
+        url: Optional[str] = None,
+        auth_type: Optional[str] = None,
+        spec_path: Optional[str] = None,
+        credentials: Optional[dict] = None,
+        extras: Optional[dict] = None,
+    ) -> dict:
+        """Test a candidate MCP server connection (`POST /mcp-rest/test/connection`).
+
+        Body is a NewMCPServerRequest — pass the same fields you would to
+        `add_mcp_server`. Useful for validating provider URL + auth before
+        registering.
+        """
+        body = self._build_mcp_server_body(
+            None,
+            None,
+            None,
+            None,
+            transport,
+            url,
+            auth_type,
+            spec_path,
+            None,
+            None,
+            None,
+            credentials,
+            extras,
+        )
+        return await self._request("POST", "/mcp-rest/test/connection", json=body)
+
+    async def discover_mcp_servers(
+        self,
+        query: Optional[str] = None,
+        category: Optional[str] = None,
+    ) -> Any:
+        """Search the public MCP server registry (`GET /v1/mcp/discover`).
+
+        Both filters are optional query params.
+        """
+        params = {k: v for k, v in {"query": query, "category": category}.items() if v is not None}
+        return await self._request("GET", "/v1/mcp/discover", params=params or None)
+
+    async def get_mcp_openapi_registry(self) -> Any:
+        """Get the OpenAPI registry of MCP servers (`GET /v1/mcp/openapi-registry`)."""
+        return await self._request("GET", "/v1/mcp/openapi-registry")
+
+    async def get_mcp_registry(self) -> Any:
+        """Get the MCP servers registry JSON (`GET /v1/mcp/registry.json`)."""
+        return await self._request("GET", "/v1/mcp/registry.json")
+
+    async def list_mcp_access_groups(self) -> Any:
+        """List MCP access groups (`GET /v1/mcp/access_groups`).
+
+        Distinct from model access groups (`/access_group/list`, in #535) and
+        unified user access groups (`/v1/unified_access_group`, in #536) — these
+        gate keys/teams against MCP servers specifically.
+        """
+        return await self._request("GET", "/v1/mcp/access_groups")
+
+    async def make_mcp_servers_public(self, mcp_server_ids: list[str]) -> dict:
+        """Publish MCP servers to the public hub (`POST /v1/mcp/make_public`).
+
+        Body is `{"mcp_server_ids": [...]}` per upstream `MakeMCPServersPublicRequest`.
+        """
+        return await self._request(
+            "POST", "/v1/mcp/make_public", json={"mcp_server_ids": mcp_server_ids}
+        )
+
+    async def get_public_mcp_hub(self) -> Any:
+        """Get the public MCP hub catalog (`GET /public/mcp_hub`)."""
+        return await self._request("GET", "/public/mcp_hub")
+
+    async def list_mcp_user_credentials(self) -> Any:
+        """List the caller's stored MCP user credentials (`GET /v1/mcp/user-credentials`).
+
+        Returns one entry per server the caller has provided credentials for;
+        credential values are not included.
+        """
+        return await self._request("GET", "/v1/mcp/user-credentials")
+
+    async def set_mcp_user_credential(
+        self,
+        server_id: str,
+        oauth: bool = False,
+        credential: Optional[str] = None,
+        save: Optional[bool] = None,
+        access_token: Optional[str] = None,
+        refresh_token: Optional[str] = None,
+        expires_in: Optional[int] = None,
+        scopes: Optional[list[str]] = None,
+    ) -> dict:
+        """Set the caller's user credential for an MCP server.
+
+        Routes to `POST /v1/mcp/server/{server_id}/oauth-user-credential` when
+        `oauth=True`, else `POST /v1/mcp/server/{server_id}/user-credential`.
+
+        Non-oauth body (`MCPUserCredentialRequest`): `credential` (required),
+        `save` (optional bool).
+
+        OAuth body (`MCPOAuthUserCredentialRequest`): `access_token` (required),
+        `refresh_token`, `expires_in`, `scopes`.
+        """
+        if oauth:
+            body = self._build_body(
+                {
+                    "access_token": access_token,
+                    "refresh_token": refresh_token,
+                    "expires_in": expires_in,
+                    "scopes": scopes,
+                }
+            )
+            path = f"/v1/mcp/server/{server_id}/oauth-user-credential"
+        else:
+            body = self._build_body({"credential": credential, "save": save})
+            path = f"/v1/mcp/server/{server_id}/user-credential"
+        return await self._request("POST", path, json=body)
+
+    async def delete_mcp_user_credential(self, server_id: str, oauth: bool = False) -> dict:
+        """Delete the caller's user credential for an MCP server.
+
+        Routes to `DELETE /v1/mcp/server/{server_id}/oauth-user-credential`
+        when `oauth=True`, else `DELETE /v1/mcp/server/{server_id}/user-credential`.
+        """
+        suffix = "oauth-user-credential" if oauth else "user-credential"
+        return await self._request("DELETE", f"/v1/mcp/server/{server_id}/{suffix}")
+
+    async def get_mcp_oauth_user_credential_status(self, server_id: str) -> dict:
+        """Get OAuth credential status for an MCP server (`GET /v1/mcp/server/{id}/oauth-user-credential/status`).
+
+        Returns whether the caller has a valid OAuth credential for the server
+        and (optionally) when it expires.
+        """
+        return await self._request(
+            "GET", f"/v1/mcp/server/{server_id}/oauth-user-credential/status"
+        )
+
+    async def get_mcp_client_ip(self) -> dict:
+        """Get the caller's resolved client IP (`GET /v1/mcp/network/client-ip`).
+
+        Useful for diagnosing IP-allowlist / proxy-header issues without
+        bouncing through an external service.
+        """
+        return await self._request("GET", "/v1/mcp/network/client-ip")

--- a/src/server.py
+++ b/src/server.py
@@ -180,6 +180,61 @@ RESPONSE_FIELDS: dict[str, dict[str, Optional[list[str]]]] = {
         ],
         "full": None,
     },
+    "mcp_server": {
+        "minimal": ["server_id", "alias"],
+        "standard": [
+            "server_id",
+            "server_name",
+            "alias",
+            "description",
+            "transport",
+            "url",
+            "auth_type",
+            "mcp_access_groups",
+            "allowed_tools",
+            "approval_status",
+        ],
+        "full": None,
+    },
+    "mcp_tool": {
+        "minimal": ["name"],
+        "standard": ["name", "description", "server_id", "inputSchema"],
+        "full": None,
+    },
+    "mcp_submission": {
+        "minimal": ["server_id", "approval_status"],
+        "standard": [
+            "server_id",
+            "server_name",
+            "alias",
+            "transport",
+            "url",
+            "approval_status",
+            "submitted_by",
+            "submitted_at",
+        ],
+        "full": None,
+    },
+    "mcp_credential": {
+        # Standard never includes the raw credential value — listing endpoints
+        # don't return it either, but this guards against future upstream
+        # additions.
+        "minimal": ["server_id"],
+        "standard": ["server_id", "has_credential", "oauth_enabled", "expires_at"],
+        "full": None,
+    },
+    "mcp_health": {
+        "minimal": ["server_id", "status"],
+        "standard": [
+            "server_id",
+            "server_name",
+            "status",
+            "last_checked",
+            "latency_ms",
+            "error_message",
+        ],
+        "full": None,
+    },
 }
 
 VALID_VERBOSITY_LEVELS = {"minimal", "standard", "full"}
@@ -1828,6 +1883,425 @@ async def test_model_connection(
         model_info: optional deployment metadata.
     """
     return await get_client().test_model_connection(litellm_params, mode, model_info)
+
+
+# ── MCP Gateway: server CRUD ──
+
+
+@mcp.tool()
+async def list_mcp_servers(team_id: Optional[str] = None, verbosity: str = "standard") -> Any:
+    """List registered upstream MCP servers (`GET /v1/mcp/server`).
+
+    Args:
+        team_id: optional team filter.
+        verbosity: 'minimal' / 'standard' / 'full'.
+    """
+    payload = await get_client().list_mcp_servers(team_id)
+    return _filter_response(payload, "mcp_server", verbosity)
+
+
+@mcp.tool()
+async def get_mcp_server(server_id: str, verbosity: str = "standard") -> dict:
+    """Get a single MCP server by id (`GET /v1/mcp/server/{server_id}`).
+
+    Args:
+        server_id: upstream server id (UUID-shaped).
+        verbosity: 'minimal' / 'standard' / 'full'.
+    """
+    payload = await get_client().get_mcp_server(server_id)
+    return _filter_response(payload, "mcp_server", verbosity)
+
+
+@mcp.tool()
+async def add_mcp_server(
+    transport: str,
+    server_name: Optional[str] = None,
+    alias: Optional[str] = None,
+    description: Optional[str] = None,
+    url: Optional[str] = None,
+    auth_type: Optional[str] = None,
+    spec_path: Optional[str] = None,
+    mcp_info: Optional[dict] = None,
+    mcp_access_groups: Optional[list[str]] = None,
+    allowed_tools: Optional[list[str]] = None,
+    credentials: Optional[dict] = None,
+    server_id: Optional[str] = None,
+    extras: Optional[dict] = None,
+) -> dict:
+    """Admin-register an upstream MCP server (`POST /v1/mcp/server`).
+
+    Distinct from `register_mcp_server`: admin path creates servers in
+    approved state directly, no review workflow.
+
+    Args:
+        transport: required (`http`, `sse`, `stdio`). Gateway brokers HTTP/SSE.
+        url: HTTP/SSE endpoint URL (e.g. `https://mcp.context7.com/mcp`).
+        auth_type: `none`, `api_key`, `oauth2`.
+        mcp_access_groups: gate this server behind named access groups.
+        allowed_tools: optional whitelist of tool names from this upstream.
+        extras: any other NewMCPServerRequest field (static_headers, oauth2_flow,
+            tool_name_to_display_name, allow_all_keys, etc.).
+    """
+    return await get_client().add_mcp_server(
+        transport,
+        server_name,
+        alias,
+        description,
+        url,
+        auth_type,
+        spec_path,
+        mcp_info,
+        mcp_access_groups,
+        allowed_tools,
+        credentials,
+        server_id,
+        extras,
+    )
+
+
+@mcp.tool()
+async def update_mcp_server(
+    server_id: str,
+    server_name: Optional[str] = None,
+    alias: Optional[str] = None,
+    description: Optional[str] = None,
+    transport: Optional[str] = None,
+    url: Optional[str] = None,
+    auth_type: Optional[str] = None,
+    spec_path: Optional[str] = None,
+    mcp_info: Optional[dict] = None,
+    mcp_access_groups: Optional[list[str]] = None,
+    allowed_tools: Optional[list[str]] = None,
+    credentials: Optional[dict] = None,
+    extras: Optional[dict] = None,
+) -> dict:
+    """Admin-update an MCP server (`PUT /v1/mcp/server`).
+
+    Note: `server_id` goes in the body, not the path — UpdateMCPServerRequest
+    treats it as the row identifier.
+    """
+    return await get_client().update_mcp_server(
+        server_id,
+        server_name,
+        alias,
+        description,
+        transport,
+        url,
+        auth_type,
+        spec_path,
+        mcp_info,
+        mcp_access_groups,
+        allowed_tools,
+        credentials,
+        extras,
+    )
+
+
+@mcp.tool()
+async def delete_mcp_server(server_id: str) -> dict:
+    """Delete an MCP server (`DELETE /v1/mcp/server/{server_id}`)."""
+    return await get_client().delete_mcp_server(server_id)
+
+
+@mcp.tool()
+async def register_mcp_server(
+    transport: str,
+    server_name: Optional[str] = None,
+    alias: Optional[str] = None,
+    description: Optional[str] = None,
+    url: Optional[str] = None,
+    auth_type: Optional[str] = None,
+    spec_path: Optional[str] = None,
+    mcp_info: Optional[dict] = None,
+    mcp_access_groups: Optional[list[str]] = None,
+    allowed_tools: Optional[list[str]] = None,
+    credentials: Optional[dict] = None,
+    extras: Optional[dict] = None,
+) -> dict:
+    """Self-register an MCP server (`POST /v1/mcp/server/register`).
+
+    User-facing submission path: creates a server in `pending` approval state.
+    An admin then approves / rejects via the submissions workflow tools.
+    Use `add_mcp_server` for the direct admin-register path.
+    """
+    return await get_client().register_mcp_server(
+        transport,
+        server_name,
+        alias,
+        description,
+        url,
+        auth_type,
+        spec_path,
+        mcp_info,
+        mcp_access_groups,
+        allowed_tools,
+        credentials,
+        extras,
+    )
+
+
+# ── MCP Gateway: submissions workflow ──
+
+
+@mcp.tool()
+async def list_mcp_server_submissions(verbosity: str = "standard") -> Any:
+    """List pending MCP server submissions (`GET /v1/mcp/server/submissions`).
+
+    Args:
+        verbosity: 'minimal' / 'standard' / 'full' (filters to mcp_submission shape).
+    """
+    payload = await get_client().list_mcp_server_submissions()
+    return _filter_response(payload, "mcp_submission", verbosity)
+
+
+@mcp.tool()
+async def approve_mcp_server_submission(server_id: str) -> dict:
+    """Approve a pending MCP submission (`PUT /v1/mcp/server/{id}/approve`).
+
+    Promotes the submission to approved/active state.
+    """
+    return await get_client().approve_mcp_server_submission(server_id)
+
+
+@mcp.tool()
+async def reject_mcp_server_submission(server_id: str, review_notes: Optional[str] = None) -> dict:
+    """Reject a pending MCP submission (`PUT /v1/mcp/server/{id}/reject`).
+
+    Args:
+        server_id: pending submission id.
+        review_notes: optional rejection reason captured upstream.
+    """
+    return await get_client().reject_mcp_server_submission(server_id, review_notes)
+
+
+# ── MCP Gateway: health ──
+
+
+@mcp.tool()
+async def check_mcp_servers_health(
+    server_ids: Optional[str] = None, verbosity: str = "standard"
+) -> dict:
+    """Probe upstream MCP server health (`GET /v1/mcp/server/health`).
+
+    Args:
+        server_ids: optional upstream-comma-separated string of server ids.
+        verbosity: 'minimal' / 'standard' / 'full' (filters to mcp_health shape).
+    """
+    payload = await get_client().check_mcp_servers_health(server_ids)
+    return _filter_response(payload, "mcp_health", verbosity)
+
+
+# ── MCP Gateway: tool discovery & invocation ──
+
+
+@mcp.tool()
+async def list_mcp_tools(verbosity: str = "standard") -> Any:
+    """List tools across all registered MCP servers (`GET /v1/mcp/tools`).
+
+    Args:
+        verbosity: 'minimal' / 'standard' / 'full' (filters to mcp_tool shape).
+    """
+    payload = await get_client().list_mcp_tools()
+    return _filter_response(payload, "mcp_tool", verbosity)
+
+
+@mcp.tool()
+async def list_mcp_tools_rest(server_id: Optional[str] = None, verbosity: str = "standard") -> Any:
+    """List tools (REST shape) for a registered MCP server (`GET /mcp-rest/tools/list`).
+
+    Lighter-weight per-server view than `list_mcp_tools`. Upstream returns
+    `{"tools": [...]}` — items are filtered by verbosity.
+    """
+    payload = await get_client().list_mcp_tools_rest(server_id)
+    if isinstance(payload, dict) and "tools" in payload:
+        payload = dict(payload)
+        payload["tools"] = _filter_response(payload["tools"], "mcp_tool", verbosity)
+        return payload
+    return _filter_response(payload, "mcp_tool", verbosity)
+
+
+@mcp.tool()
+async def call_mcp_tool(
+    server_id: str,
+    name: str,
+    arguments: Optional[dict] = None,
+) -> Any:
+    """Invoke a tool on a registered MCP server (`POST /mcp-rest/tools/call`).
+
+    Returns the provider-shaped tool response unmodified (typically the MCP
+    `tools/call` envelope `{"content": [...], "isError": bool}`). No verbosity
+    filtering — callers usually want the full provider output.
+
+    Args:
+        server_id: UUID of a registered MCP server.
+        name: tool name as listed by `list_mcp_tools_rest(server_id)`.
+        arguments: tool arguments dict.
+    """
+    return await get_client().call_mcp_tool(server_id, name, arguments)
+
+
+@mcp.tool()
+async def test_mcp_connection(
+    transport: str,
+    url: Optional[str] = None,
+    auth_type: Optional[str] = None,
+    spec_path: Optional[str] = None,
+    credentials: Optional[dict] = None,
+    extras: Optional[dict] = None,
+) -> dict:
+    """Test an MCP server connection without registering it (`POST /mcp-rest/test/connection`).
+
+    Body is a NewMCPServerRequest — pass the same fields you'd give to
+    `add_mcp_server`. Useful for validating URL + auth before persisting.
+    """
+    return await get_client().test_mcp_connection(
+        transport, url, auth_type, spec_path, credentials, extras
+    )
+
+
+# ── MCP Gateway: discovery / registry / hub ──
+
+
+@mcp.tool()
+async def discover_mcp_servers(query: Optional[str] = None, category: Optional[str] = None) -> Any:
+    """Search the public MCP server registry (`GET /v1/mcp/discover`).
+
+    Args:
+        query: free-text search.
+        category: registry-defined category filter.
+    """
+    return await get_client().discover_mcp_servers(query, category)
+
+
+@mcp.tool()
+async def get_mcp_openapi_registry() -> Any:
+    """Get the OpenAPI registry of MCP servers (`GET /v1/mcp/openapi-registry`).
+
+    Returns descriptors useful for tooling that prefers OpenAPI over MCP.
+    """
+    return await get_client().get_mcp_openapi_registry()
+
+
+@mcp.tool()
+async def get_mcp_registry() -> Any:
+    """Get the MCP servers registry JSON (`GET /v1/mcp/registry.json`)."""
+    return await get_client().get_mcp_registry()
+
+
+@mcp.tool()
+async def list_mcp_access_groups() -> Any:
+    """List MCP access groups (`GET /v1/mcp/access_groups`).
+
+    Distinct from the model-access-groups family (#535) and the unified user
+    access groups (#536) — these gate keys/teams against MCP servers
+    specifically.
+    """
+    return await get_client().list_mcp_access_groups()
+
+
+@mcp.tool()
+async def make_mcp_servers_public(mcp_server_ids: list[str]) -> dict:
+    """Publish MCP servers to the public hub (`POST /v1/mcp/make_public`).
+
+    Replaces (not appends) the published set with `mcp_server_ids`.
+    """
+    return await get_client().make_mcp_servers_public(mcp_server_ids)
+
+
+@mcp.tool()
+async def get_public_mcp_hub() -> Any:
+    """Get the public MCP hub catalog (`GET /public/mcp_hub`)."""
+    return await get_client().get_public_mcp_hub()
+
+
+# ── MCP Gateway: user credentials ──
+
+
+@mcp.tool()
+async def list_mcp_user_credentials(verbosity: str = "standard") -> Any:
+    """List the caller's stored MCP user credentials (`GET /v1/mcp/user-credentials`).
+
+    Returns one entry per server the caller has credentials for. Credential
+    values are not included.
+
+    Args:
+        verbosity: 'minimal' / 'standard' / 'full' (filters to mcp_credential shape).
+    """
+    payload = await get_client().list_mcp_user_credentials()
+    return _filter_response(payload, "mcp_credential", verbosity)
+
+
+@mcp.tool()
+async def set_mcp_user_credential(
+    server_id: str,
+    oauth: bool = False,
+    credential: Optional[str] = None,
+    save: Optional[bool] = None,
+    access_token: Optional[str] = None,
+    refresh_token: Optional[str] = None,
+    expires_in: Optional[int] = None,
+    scopes: Optional[list[str]] = None,
+) -> dict:
+    """Set the caller's user credential for an MCP server.
+
+    The `oauth` boolean discriminator routes between the two upstream
+    endpoints, compressing what would otherwise be two near-identical tools:
+    - `oauth=False` → `POST /v1/mcp/server/{id}/user-credential` with body
+      `{"credential": ..., "save": ...}` (MCPUserCredentialRequest).
+    - `oauth=True` → `POST /v1/mcp/server/{id}/oauth-user-credential` with body
+      `{"access_token": ..., "refresh_token": ..., "expires_in": ..., "scopes": [...]}`
+      (MCPOAuthUserCredentialRequest).
+
+    Args:
+        server_id: target MCP server id.
+        oauth: route discriminator (default False).
+        credential / save: non-oauth fields.
+        access_token / refresh_token / expires_in / scopes: oauth fields.
+    """
+    return await get_client().set_mcp_user_credential(
+        server_id,
+        oauth,
+        credential,
+        save,
+        access_token,
+        refresh_token,
+        expires_in,
+        scopes,
+    )
+
+
+@mcp.tool()
+async def delete_mcp_user_credential(server_id: str, oauth: bool = False) -> dict:
+    """Delete the caller's user credential for an MCP server.
+
+    The `oauth` boolean routes between
+    `DELETE /v1/mcp/server/{id}/oauth-user-credential` and
+    `DELETE /v1/mcp/server/{id}/user-credential`.
+    """
+    return await get_client().delete_mcp_user_credential(server_id, oauth)
+
+
+@mcp.tool()
+async def get_mcp_oauth_user_credential_status(server_id: str) -> dict:
+    """Get OAuth credential status for an MCP server (`GET /v1/mcp/server/{id}/oauth-user-credential/status`).
+
+    Returns whether the caller has a valid OAuth credential and (optionally)
+    when it expires.
+    """
+    return await get_client().get_mcp_oauth_user_credential_status(server_id)
+
+
+# ── MCP Gateway: utility ──
+
+
+@mcp.tool()
+async def get_mcp_client_ip() -> dict:
+    """Get the caller's resolved client IP (`GET /v1/mcp/network/client-ip`).
+
+    Useful for diagnosing IP-allowlist / proxy-header issues without bouncing
+    through an external service.
+    """
+    return await get_client().get_mcp_client_ip()
 
 
 # ── Entrypoint ──

--- a/tests/smoke.py
+++ b/tests/smoke.py
@@ -406,6 +406,115 @@ async def run() -> int:
             except LiteLLMAPIError as e:
                 results.append(("embed", False, f"APIError {e.status_code}: {e}"))
 
+        # MCP Gateway family — read-only paths + Context7 end-to-end.
+        servers = await client.list_mcp_servers()
+        results.append(("list_mcp_servers", True, _summarize(servers)))
+
+        # Locate Context7 (or any registered HTTP-transport server) for the
+        # end-to-end probe. We don't auto-register because TETRA's proxy
+        # already has Context7 registered; double-registration would 409.
+        first_server_id = None
+        first_server_alias = None
+        if isinstance(servers, list):
+            for s in servers:
+                if isinstance(s, dict):
+                    if s.get("alias") == "context7" or "context7" in (s.get("url") or ""):
+                        first_server_id = s.get("server_id")
+                        first_server_alias = s.get("alias")
+                        break
+            if first_server_id is None and servers and isinstance(servers[0], dict):
+                first_server_id = servers[0].get("server_id")
+                first_server_alias = servers[0].get("alias")
+
+        if first_server_id:
+            results.append(await _step("get_mcp_server", client.get_mcp_server(first_server_id)))
+        else:
+            results.append(("get_mcp_server", True, "skipped (no servers)"))
+
+        results.append(
+            await _step("list_mcp_server_submissions", client.list_mcp_server_submissions())
+        )
+        results.append(await _step("check_mcp_servers_health", client.check_mcp_servers_health()))
+        results.append(await _step("list_mcp_tools", client.list_mcp_tools()))
+        results.append(
+            await _step("list_mcp_tools_rest", client.list_mcp_tools_rest(first_server_id))
+        )
+        results.append(await _step("discover_mcp_servers", client.discover_mcp_servers()))
+        results.append(await _step("get_mcp_openapi_registry", client.get_mcp_openapi_registry()))
+        # /v1/mcp/registry.json is optional upstream — older versions / minimal
+        # configs return 404. Tolerate it and report.
+        try:
+            payload = await client.get_mcp_registry()
+            results.append(("get_mcp_registry", True, _summarize(payload)))
+        except LiteLLMAPIError as e:
+            if e.status_code == 404:
+                results.append(("get_mcp_registry", True, "404 (registry.json not enabled)"))
+            else:
+                results.append(("get_mcp_registry", False, f"APIError {e.status_code}: {e}"))
+        results.append(await _step("list_mcp_access_groups", client.list_mcp_access_groups()))
+        results.append(await _step("get_public_mcp_hub", client.get_public_mcp_hub()))
+        results.append(await _step("list_mcp_user_credentials", client.list_mcp_user_credentials()))
+        if first_server_id:
+            try:
+                payload = await client.get_mcp_oauth_user_credential_status(first_server_id)
+                results.append(("get_mcp_oauth_user_credential_status", True, _summarize(payload)))
+            except LiteLLMAPIError as e:
+                # Most servers don't have OAuth configured — 404 is acceptable.
+                if e.status_code == 404:
+                    results.append(
+                        (
+                            "get_mcp_oauth_user_credential_status",
+                            True,
+                            "404 (no oauth configured)",
+                        )
+                    )
+                else:
+                    results.append(
+                        (
+                            "get_mcp_oauth_user_credential_status",
+                            False,
+                            f"APIError {e.status_code}: {e}",
+                        )
+                    )
+        else:
+            results.append(("get_mcp_oauth_user_credential_status", True, "skipped (no servers)"))
+        results.append(await _step("get_mcp_client_ip", client.get_mcp_client_ip()))
+
+        # End-to-end: call Context7's resolve-library-id through the gateway.
+        # Master keys aren't auto-granted MCP tool access; some proxies return
+        # 403 "User not allowed" — that's an upstream auth quirk, not a wrapper
+        # bug, so we tolerate it and report it explicitly.
+        if first_server_alias == "context7" and first_server_id:
+            try:
+                payload = await client.call_mcp_tool(
+                    server_id=first_server_id,
+                    name="resolve-library-id",
+                    arguments={"libraryName": "react"},
+                )
+                content = payload.get("content") if isinstance(payload, dict) else None
+                if content:
+                    results.append(("call_mcp_tool[context7]", True, f"content[{len(content)}]"))
+                else:
+                    results.append(("call_mcp_tool[context7]", True, _summarize(payload)))
+            except LiteLLMAPIError as e:
+                # 403 here means the calling key isn't granted MCP-tool access.
+                # The wrapper sent a well-formed request; this is an upstream
+                # auth quirk (master keys aren't auto-granted). Tolerate it.
+                if e.status_code in {401, 403}:
+                    results.append(
+                        (
+                            "call_mcp_tool[context7]",
+                            True,
+                            f"{e.status_code} (caller not granted MCP access — wrapper OK)",
+                        )
+                    )
+                else:
+                    results.append(
+                        ("call_mcp_tool[context7]", False, f"APIError {e.status_code}: {e}")
+                    )
+        else:
+            results.append(("call_mcp_tool[context7]", True, "skipped (Context7 not registered)"))
+
     finally:
         await client.close()
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1207,6 +1207,348 @@ class TestTestModelConnection:
         )
 
 
+# ── MCP Gateway: server CRUD ──
+
+
+class TestListMCPServers:
+    @pytest.mark.asyncio
+    async def test_no_filter(self, mock_client):
+        mock_client.list_mcp_servers.return_value = [
+            {"server_id": "s-1", "alias": "context7", "description": "drop"}
+        ]
+        result = await src.server.list_mcp_servers(verbosity="minimal")
+        assert result == [{"server_id": "s-1", "alias": "context7"}]
+        mock_client.list_mcp_servers.assert_awaited_once_with(None)
+
+    @pytest.mark.asyncio
+    async def test_team_filter(self, mock_client):
+        mock_client.list_mcp_servers.return_value = []
+        await src.server.list_mcp_servers(team_id="t-1")
+        mock_client.list_mcp_servers.assert_awaited_once_with("t-1")
+
+
+class TestGetMCPServer:
+    @pytest.mark.asyncio
+    async def test_passes_id(self, mock_client):
+        mock_client.get_mcp_server.return_value = {
+            "server_id": "s-1",
+            "alias": "context7",
+            "transport": "http",
+            "url": "https://mcp.context7.com/mcp",
+        }
+        result = await src.server.get_mcp_server("s-1", "standard")
+        assert result["transport"] == "http"
+        mock_client.get_mcp_server.assert_awaited_once_with("s-1")
+
+
+class TestAddMCPServer:
+    @pytest.mark.asyncio
+    async def test_required_transport(self, mock_client):
+        mock_client.add_mcp_server.return_value = {"server_id": "s-1"}
+        await src.server.add_mcp_server(
+            transport="http",
+            alias="context7",
+            url="https://mcp.context7.com/mcp",
+            auth_type="none",
+        )
+        call = mock_client.add_mcp_server.await_args
+        assert call.args[0] == "http"
+        assert call.args[2] == "context7"
+        assert call.args[4] == "https://mcp.context7.com/mcp"
+        assert call.args[5] == "none"
+
+
+class TestUpdateMCPServer:
+    @pytest.mark.asyncio
+    async def test_required_id(self, mock_client):
+        mock_client.update_mcp_server.return_value = {"ok": True}
+        await src.server.update_mcp_server("s-1", description="updated")
+        mock_client.update_mcp_server.assert_awaited_once_with(
+            "s-1", None, None, "updated", None, None, None, None, None, None, None, None, None
+        )
+
+
+class TestDeleteMCPServer:
+    @pytest.mark.asyncio
+    async def test_passes_id(self, mock_client):
+        mock_client.delete_mcp_server.return_value = {"deleted": True}
+        await src.server.delete_mcp_server("s-1")
+        mock_client.delete_mcp_server.assert_awaited_once_with("s-1")
+
+
+class TestRegisterMCPServer:
+    @pytest.mark.asyncio
+    async def test_minimal(self, mock_client):
+        mock_client.register_mcp_server.return_value = {
+            "server_id": "s-1",
+            "approval_status": "pending",
+        }
+        await src.server.register_mcp_server(
+            transport="http",
+            alias="my-mcp",
+            url="https://example.com/mcp",
+        )
+        call = mock_client.register_mcp_server.await_args
+        assert call.args[0] == "http"
+        assert call.args[2] == "my-mcp"
+
+
+# ── MCP Gateway: submissions ──
+
+
+class TestListMCPServerSubmissions:
+    @pytest.mark.asyncio
+    async def test_filters_to_submission_shape(self, mock_client):
+        mock_client.list_mcp_server_submissions.return_value = [
+            {
+                "server_id": "s-1",
+                "approval_status": "pending",
+                "alias": "candidate",
+                "transport": "http",
+                "url": "https://x.com/mcp",
+                "drop_me": True,
+            }
+        ]
+        result = await src.server.list_mcp_server_submissions("standard")
+        assert "drop_me" not in result[0]
+        assert result[0]["approval_status"] == "pending"
+
+
+class TestApproveMCPServerSubmission:
+    @pytest.mark.asyncio
+    async def test_passes_id(self, mock_client):
+        mock_client.approve_mcp_server_submission.return_value = {"ok": True}
+        await src.server.approve_mcp_server_submission("s-1")
+        mock_client.approve_mcp_server_submission.assert_awaited_once_with("s-1")
+
+
+class TestRejectMCPServerSubmission:
+    @pytest.mark.asyncio
+    async def test_with_notes(self, mock_client):
+        mock_client.reject_mcp_server_submission.return_value = {"ok": True}
+        await src.server.reject_mcp_server_submission("s-1", review_notes="duplicate")
+        mock_client.reject_mcp_server_submission.assert_awaited_once_with("s-1", "duplicate")
+
+    @pytest.mark.asyncio
+    async def test_no_notes(self, mock_client):
+        mock_client.reject_mcp_server_submission.return_value = {"ok": True}
+        await src.server.reject_mcp_server_submission("s-1")
+        mock_client.reject_mcp_server_submission.assert_awaited_once_with("s-1", None)
+
+
+# ── MCP Gateway: health ──
+
+
+class TestCheckMCPServersHealth:
+    @pytest.mark.asyncio
+    async def test_filters_passed(self, mock_client):
+        mock_client.check_mcp_servers_health.return_value = [
+            {"server_id": "s-1", "status": "healthy", "latency_ms": 42, "internal": "drop"}
+        ]
+        result = await src.server.check_mcp_servers_health(server_ids="s-1,s-2")
+        assert "internal" not in result[0]
+        mock_client.check_mcp_servers_health.assert_awaited_once_with("s-1,s-2")
+
+
+# ── MCP Gateway: tool discovery & invocation ──
+
+
+class TestListMCPTools:
+    @pytest.mark.asyncio
+    async def test_filters_to_tool_shape(self, mock_client):
+        mock_client.list_mcp_tools.return_value = [
+            {
+                "name": "resolve-library-id",
+                "description": "...",
+                "server_id": "s-1",
+                "inputSchema": {"type": "object"},
+                "drop_me": True,
+            }
+        ]
+        result = await src.server.list_mcp_tools("standard")
+        assert "drop_me" not in result[0]
+        assert result[0]["name"] == "resolve-library-id"
+
+
+class TestListMCPToolsRest:
+    @pytest.mark.asyncio
+    async def test_passes_server_id_and_filters_tools_array(self, mock_client):
+        mock_client.list_mcp_tools_rest.return_value = {
+            "tools": [
+                {"name": "tool-a", "description": "...", "drop_me": True},
+                {"name": "tool-b", "description": "..."},
+            ]
+        }
+        result = await src.server.list_mcp_tools_rest(server_id="s-1", verbosity="minimal")
+        assert result["tools"] == [{"name": "tool-a"}, {"name": "tool-b"}]
+        mock_client.list_mcp_tools_rest.assert_awaited_once_with("s-1")
+
+    @pytest.mark.asyncio
+    async def test_handles_list_payload(self, mock_client):
+        mock_client.list_mcp_tools_rest.return_value = [
+            {"name": "tool-a"},
+        ]
+        result = await src.server.list_mcp_tools_rest()
+        assert result == [{"name": "tool-a"}]
+
+
+class TestCallMCPTool:
+    @pytest.mark.asyncio
+    async def test_basic(self, mock_client):
+        mock_client.call_mcp_tool.return_value = {"content": [{"type": "text", "text": "ok"}]}
+        await src.server.call_mcp_tool(
+            server_id="s-1", name="resolve-library-id", arguments={"libraryName": "react"}
+        )
+        mock_client.call_mcp_tool.assert_awaited_once_with(
+            "s-1", "resolve-library-id", {"libraryName": "react"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_arguments(self, mock_client):
+        mock_client.call_mcp_tool.return_value = {"content": []}
+        await src.server.call_mcp_tool(server_id="s-1", name="ping")
+        mock_client.call_mcp_tool.assert_awaited_once_with("s-1", "ping", None)
+
+
+class TestTestMCPConnection:
+    @pytest.mark.asyncio
+    async def test_required_transport(self, mock_client):
+        mock_client.test_mcp_connection.return_value = {"status": "ok"}
+        await src.server.test_mcp_connection(
+            transport="http", url="https://example.com/mcp", auth_type="none"
+        )
+        mock_client.test_mcp_connection.assert_awaited_once_with(
+            "http", "https://example.com/mcp", "none", None, None, None
+        )
+
+
+# ── MCP Gateway: discovery / registry / hub ──
+
+
+class TestDiscoverMCPServers:
+    @pytest.mark.asyncio
+    async def test_filters_passed(self, mock_client):
+        mock_client.discover_mcp_servers.return_value = []
+        await src.server.discover_mcp_servers(query="docs", category="dev-tools")
+        mock_client.discover_mcp_servers.assert_awaited_once_with("docs", "dev-tools")
+
+
+class TestGetMCPOpenAPIRegistry:
+    @pytest.mark.asyncio
+    async def test_passthrough(self, mock_client):
+        mock_client.get_mcp_openapi_registry.return_value = {"version": 1}
+        result = await src.server.get_mcp_openapi_registry()
+        assert result == {"version": 1}
+
+
+class TestGetMCPRegistry:
+    @pytest.mark.asyncio
+    async def test_passthrough(self, mock_client):
+        mock_client.get_mcp_registry.return_value = {"servers": []}
+        result = await src.server.get_mcp_registry()
+        assert result == {"servers": []}
+
+
+class TestListMCPAccessGroups:
+    @pytest.mark.asyncio
+    async def test_passthrough(self, mock_client):
+        mock_client.list_mcp_access_groups.return_value = ["engineering", "ops"]
+        result = await src.server.list_mcp_access_groups()
+        assert result == ["engineering", "ops"]
+
+
+class TestMakeMCPServersPublic:
+    @pytest.mark.asyncio
+    async def test_passes_ids(self, mock_client):
+        mock_client.make_mcp_servers_public.return_value = {"ok": True}
+        await src.server.make_mcp_servers_public(["s-1", "s-2"])
+        mock_client.make_mcp_servers_public.assert_awaited_once_with(["s-1", "s-2"])
+
+
+class TestGetPublicMCPHub:
+    @pytest.mark.asyncio
+    async def test_passthrough(self, mock_client):
+        mock_client.get_public_mcp_hub.return_value = {"servers": []}
+        result = await src.server.get_public_mcp_hub()
+        assert result == {"servers": []}
+
+
+# ── MCP Gateway: user credentials ──
+
+
+class TestListMCPUserCredentials:
+    @pytest.mark.asyncio
+    async def test_filters_to_credential_shape(self, mock_client):
+        mock_client.list_mcp_user_credentials.return_value = [
+            {
+                "server_id": "s-1",
+                "has_credential": True,
+                "oauth_enabled": False,
+                "drop_me": True,
+            }
+        ]
+        result = await src.server.list_mcp_user_credentials("standard")
+        assert "drop_me" not in result[0]
+
+
+class TestSetMCPUserCredential:
+    @pytest.mark.asyncio
+    async def test_non_oauth(self, mock_client):
+        mock_client.set_mcp_user_credential.return_value = {"ok": True}
+        await src.server.set_mcp_user_credential(server_id="s-1", credential="sk-x", save=True)
+        mock_client.set_mcp_user_credential.assert_awaited_once_with(
+            "s-1", False, "sk-x", True, None, None, None, None
+        )
+
+    @pytest.mark.asyncio
+    async def test_oauth(self, mock_client):
+        mock_client.set_mcp_user_credential.return_value = {"ok": True}
+        await src.server.set_mcp_user_credential(
+            server_id="s-1",
+            oauth=True,
+            access_token="at-x",
+            refresh_token="rt-x",
+            expires_in=3600,
+            scopes=["read"],
+        )
+        mock_client.set_mcp_user_credential.assert_awaited_once_with(
+            "s-1", True, None, None, "at-x", "rt-x", 3600, ["read"]
+        )
+
+
+class TestDeleteMCPUserCredential:
+    @pytest.mark.asyncio
+    async def test_non_oauth(self, mock_client):
+        mock_client.delete_mcp_user_credential.return_value = {"deleted": True}
+        await src.server.delete_mcp_user_credential("s-1")
+        mock_client.delete_mcp_user_credential.assert_awaited_once_with("s-1", False)
+
+    @pytest.mark.asyncio
+    async def test_oauth(self, mock_client):
+        mock_client.delete_mcp_user_credential.return_value = {"deleted": True}
+        await src.server.delete_mcp_user_credential("s-1", oauth=True)
+        mock_client.delete_mcp_user_credential.assert_awaited_once_with("s-1", True)
+
+
+class TestGetMCPOAuthUserCredentialStatus:
+    @pytest.mark.asyncio
+    async def test_passes_id(self, mock_client):
+        mock_client.get_mcp_oauth_user_credential_status.return_value = {"valid": True}
+        await src.server.get_mcp_oauth_user_credential_status("s-1")
+        mock_client.get_mcp_oauth_user_credential_status.assert_awaited_once_with("s-1")
+
+
+# ── MCP Gateway: utility ──
+
+
+class TestGetMCPClientIp:
+    @pytest.mark.asyncio
+    async def test_passthrough(self, mock_client):
+        mock_client.get_mcp_client_ip.return_value = {"client_ip": "10.0.0.1"}
+        result = await src.server.get_mcp_client_ip()
+        assert result == {"client_ip": "10.0.0.1"}
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client

--- a/uv.lock
+++ b/uv.lock
@@ -546,7 +546,7 @@ wheels = [
 
 [[package]]
 name = "litellm-mcp"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

US [#558](https://taiga.tetra-ai.fr/project/tetra/us/558) — MCP Gateway (LiteLLM as MCP-of-MCPs).

Adds 25 tools across 6 families that let the LiteLLM proxy broker upstream HTTP-transport MCP servers:

- **Server CRUD (6):** `list_mcp_servers`, `get_mcp_server`, `add_mcp_server`, `update_mcp_server`, `delete_mcp_server`, `register_mcp_server` (user-pending vs admin-approved paths).
- **Submissions (3):** `list_mcp_server_submissions`, `approve_mcp_server_submission`, `reject_mcp_server_submission`.
- **Health (1):** `check_mcp_servers_health`.
- **Tool discovery & invocation (4):** `list_mcp_tools`, `list_mcp_tools_rest`, `call_mcp_tool`, `test_mcp_connection`.
- **Discovery / registry / hub (6):** `discover_mcp_servers`, `get_mcp_openapi_registry`, `get_mcp_registry`, `list_mcp_access_groups`, `make_mcp_servers_public`, `get_public_mcp_hub`.
- **User credentials (4):** `list_mcp_user_credentials`, `set_mcp_user_credential(server_id, credential, oauth: bool)` (compresses oauth+non-oauth POST), `delete_mcp_user_credential(server_id, oauth: bool)` (compresses DELETE), `get_mcp_oauth_user_credential_status`.
- **Utility (1):** `get_mcp_client_ip`.

Plus 5 new `RESPONSE_FIELDS` shapes (`mcp_server`, `mcp_tool`, `mcp_submission`, `mcp_credential`, `mcp_health`).

Server tool count: **83 → 108**.

## Test plan

- [x] Unit tests (`uv run pytest`) — **148 passing** (31 new, 117 pre-existing).
- [x] Live smoke (`uv run python tests/smoke.py` against TETRA's LiteLLM proxy) — **57/57 passing**, including end-to-end probe of Context7 (`https://mcp.context7.com`) via the gateway.
- [x] `ruff check` + `ruff format` clean.
- [x] CI green (let actions run).

## Upstream quirks documented in CLAUDE.md

- `PUT /v1/mcp/server` carries `server_id` in the body (not the path) — opposite of GET/DELETE.
- `POST /mcp-rest/tools/call` has no documented body schema in OpenAPI; expects `{"server_id", "name", "arguments"}` per the MCP `tools/call` shape.
- MCP tool invocation has a per-user access check that overrides the server's `allow_all_keys`. Master keys aren't auto-granted; granting access is a deployment concern (assign the user to an MCP access group, or attach `mcp_servers=[<id>]` to the calling key).
- `GET /v1/mcp/registry.json` is optional upstream — older / minimal proxy configs return 404.

## Out of scope (permanent skips, no RFC issue — transport-level not admin)

- 14 OAuth-flow endpoints: `.well-known/*` (8), `/register`, `/authorize`, `/callback`, `/token`, `/{server}/authorize|register|token`, `oauth/session`. These are for OAuth clients connecting to MCP servers, not admin tooling.
- `/mcp-rest/test/tools/list` (redundant with `list_mcp_tools` for testing).

## Follow-up

Taiga task [#686](https://taiga.tetra-ai.fr/project/tetra/task/686) (per-user creds reassessment vs the 2026-03-24 mcp-front decision) stays open as an architecture-decision tracker. Not blocking this PR.

## Release

semrel will cut `v1.4.0` on merge to `master`.