### PR TITLE
feat: MCP-Toolset tools (US #688 — 5 tools, semrel 1.x.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,18 +14,19 @@ MCP server for the LiteLLM proxy. Python 3.12, fastmcp (`mcp.server.fastmcp`), h
 ## Conventions
 
 - All read-shaped tools accept a `verbosity: str` argument (`minimal` / `standard` / `full`) and route through `_filter_response`. Write/admin tools generally don't filter (`update_model`, `add_model`, etc. return upstream as-is).
-- Add new resource shapes to `RESPONSE_FIELDS` in `src/server.py`. Current shapes: `model`, `access_group`, `credential`, `key`, `public_hub`, `user`, `customer`, `organization`, `project`, `user_access_group`, `budget`, `spend_record`, `chat_completion`, `embedding`, `health`, `mcp_server`, `mcp_tool`, `mcp_submission`, `mcp_credential`, `mcp_health`. The `credential.standard` and `mcp_credential.standard` shapes intentionally drop credential values to avoid leaking secrets — use `full` to inspect.
+- Add new resource shapes to `RESPONSE_FIELDS` in `src/server.py`. Current shapes: `model`, `access_group`, `credential`, `key`, `public_hub`, `user`, `customer`, `organization`, `project`, `user_access_group`, `budget`, `spend_record`, `chat_completion`, `embedding`, `health`, `mcp_server`, `mcp_tool`, `mcp_submission`, `mcp_credential`, `mcp_health`, `mcp_toolset`. The `credential.standard` and `mcp_credential.standard` shapes intentionally drop credential values to avoid leaking secrets — use `full` to inspect.
 - New endpoints go on `LiteLLMClient` first, then a thin `@mcp.tool()` wrapper in `server.py`.
 - For body schemas with many optional fields (`GenerateKeyRequest`, `UpdateKeyRequest`, `RegenerateKeyRequest`, `NewUserRequest`, `NewCustomerRequest`, `NewOrganizationRequest`, `NewProjectRequest`), expose ~12 common fields as named args and accept the long tail through an `extras: Optional[dict]` argument (merged into the body via `_build_body`/`_build_key_body`).
 - Keep transport agnostic: never call `print` / write to stdout in stdio mode.
 
-## Current scope (US #534 + #535 + #536 + #596 + #558)
+## Current scope (US #534 + #535 + #536 + #596 + #558 + #688)
 
 - **#534 (v1.0.0):** foundation, `list_models`.
 - **#535 (v1.1.0):** 32 admin tools — Models (5), Model Hub (5), Access Groups (5), Credentials (6), Keys (11). All wrapped with unit tests against `AsyncMock(LiteLLMClient)`.
 - **#536 (v1.2.0):** 31 identity tools — Internal Users (5), Customers (7), Organizations (9, incl. member CRUD), Projects (5), Unified User Access Groups (5).
 - **#596 (v1.3.0):** 19 tools — Budgets (6), Spend (5), Execution (3 — chat/completion/embed, synchronous), Health (5).
-- **#558:** 25 MCP-Gateway tools — Server CRUD (6), Submissions (3), Health (1), Tool discovery & invocation (4), Discovery/registry/hub (6), User credentials (4), Utility (1). Lets the proxy broker upstream HTTP-transport MCP servers and list/invoke their tools.
+- **#558 (v1.4.0):** 25 MCP-Gateway tools — Server CRUD (6), Submissions (3), Health (1), Tool discovery & invocation (4), Discovery/registry/hub (6), User credentials (4), Utility (1). Lets the proxy broker upstream HTTP-transport MCP servers and list/invoke their tools.
+- **#688:** 5 MCP-Toolset tools — `list_mcp_toolsets`, `get_mcp_toolset`, `add_mcp_toolset`, `update_mcp_toolset`, `delete_mcp_toolset`. Toolsets are named bundles of tools sourced from one or more registered MCP servers; the proxy then exposes each toolset as a brokered MCP endpoint at `/toolset/{name}/mcp` (transport-level, not wrapped).
 
 ### Upstream quirks
 
@@ -42,6 +43,8 @@ MCP server for the LiteLLM proxy. Python 3.12, fastmcp (`mcp.server.fastmcp`), h
 - `POST /mcp-rest/tools/call` has no documented body schema in OpenAPI but expects `{"server_id": ..., "name": ..., "arguments": {...}}` per the MCP `tools/call` shape.
 - MCP tool invocation (`call_mcp_tool`) does **not** rely on the registered server's `allow_all_keys` flag alone — there is a per-user MCP-access check upstream that returns "User not allowed to call this tool" even for the master key, unless the calling user is a member of the server's `mcp_access_groups`. Wrapper sends a correct request; granting access is a deployment concern (assign the calling user to an MCP access group, or attach `mcp_servers=[<id>]` to the calling key).
 - `GET /v1/mcp/registry.json` is optional upstream — older / minimal proxy configs return 404. Wrapper returns the upstream payload as-is.
+- `PUT /v1/mcp/toolset` carries `toolset_id` in the body (per `UpdateMCPToolsetRequest`), not the path — same convention as `/v1/mcp/server`.
+- Toolset names share the upstream tool-name validation (A–Z, a–z, 0–9, underscore, dash, dot — no spaces). Spaces in `toolset_name` return HTTP 400 with `Invalid MCP tool prefix`.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ Identity slice (US #536) added 31 tools covering internal users, customers,
 organizations (with member management), projects, and unified user access
 groups. Spend/execution/health slice (US #596) added 19 tools covering budgets,
 spend reporting, the three core execution verbs (chat / completion / embed),
-and admin health probes. MCP-Gateway slice (US #558) adds 25 tools that let
+and admin health probes. MCP-Gateway slice (US #558) added 25 tools that let
 the LiteLLM proxy act as an MCP-of-MCPs: register upstream HTTP-transport MCP
-servers and list / invoke their tools through the proxy. Governance and
-passthrough (#538) is the remaining deferred slice.
+servers and list / invoke their tools through the proxy. MCP-Toolsets slice
+(US #688) adds 5 tools to manage named bundles of cross-server tools.
+Governance and passthrough (#538) is the remaining deferred slice.
 
 ## Setup
 
@@ -302,6 +303,18 @@ via the `body: dict` argument.
 | `get_mcp_client_ip` | `GET /v1/mcp/network/client-ip` |
 
 The `oauth: bool` discriminator on `set_mcp_user_credential` and `delete_mcp_user_credential` compresses the OAuth + non-OAuth endpoints into one tool each. Non-OAuth body: `{"credential": ..., "save": ...}`. OAuth body: `{"access_token": ..., "refresh_token": ..., "expires_in": ..., "scopes": [...]}`.
+
+### MCP Gateway — Toolsets (5)
+
+| Tool | Endpoint |
+|------|----------|
+| `list_mcp_toolsets` | `GET /v1/mcp/toolset` |
+| `get_mcp_toolset` | `GET /v1/mcp/toolset/{toolset_id}` |
+| `add_mcp_toolset` | `POST /v1/mcp/toolset` |
+| `update_mcp_toolset` | `PUT /v1/mcp/toolset` (toolset_id in body) |
+| `delete_mcp_toolset` | `DELETE /v1/mcp/toolset/{toolset_id}` |
+
+Toolsets are named bundles of tools sourced from one or more registered MCP servers (e.g. a `research` toolset combining `resolve-library-id` from Context7 with `search` from another MCP). Once defined, the proxy exposes each toolset as a brokered MCP endpoint at `/toolset/{name}/mcp` — that transport route is intentionally not wrapped here.
 
 `add_mcp_server` / `update_mcp_server` / `register_mcp_server` / `test_mcp_connection` accept an `extras: dict` argument for the long tail of `NewMCPServerRequest` fields not surfaced as named args (~20 less common fields like `static_headers`, `oauth2_flow`, `tool_name_to_display_name`, `allow_all_keys`).
 

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -1971,3 +1971,62 @@ class LiteLLMClient:
         bouncing through an external service.
         """
         return await self._request("GET", "/v1/mcp/network/client-ip")
+
+    # ── MCP Toolset operations ──
+    #
+    # Toolsets are named bundles of tools sourced from one or more registered
+    # MCP servers (e.g. a `research` toolset combining `resolve-library-id`
+    # from Context7 with `search` from another upstream). The proxy then
+    # exposes each toolset as a brokered MCP endpoint at `/toolset/{name}/mcp`
+    # — that transport route is permanent-skip (transport-level, not admin).
+
+    async def list_mcp_toolsets(self) -> Any:
+        """List defined MCP toolsets (`GET /v1/mcp/toolset`)."""
+        return await self._request("GET", "/v1/mcp/toolset")
+
+    async def get_mcp_toolset(self, toolset_id: str) -> dict:
+        """Get a single MCP toolset by id (`GET /v1/mcp/toolset/{toolset_id}`)."""
+        return await self._request("GET", f"/v1/mcp/toolset/{toolset_id}")
+
+    async def add_mcp_toolset(
+        self,
+        toolset_name: str,
+        tools: list[str],
+        description: Optional[str] = None,
+    ) -> dict:
+        """Create an MCP toolset (`POST /v1/mcp/toolset`).
+
+        Body shape per `NewMCPToolsetRequest`: `toolset_name` (required),
+        `tools` (required list of tool identifiers — typically
+        `<server_alias>/<tool_name>` strings), optional `description`.
+        """
+        body: dict[str, Any] = {"toolset_name": toolset_name, "tools": tools}
+        if description is not None:
+            body["description"] = description
+        return await self._request("POST", "/v1/mcp/toolset", json=body)
+
+    async def update_mcp_toolset(
+        self,
+        toolset_id: str,
+        toolset_name: Optional[str] = None,
+        description: Optional[str] = None,
+        tools: Optional[list[str]] = None,
+    ) -> dict:
+        """Update an MCP toolset (`PUT /v1/mcp/toolset`).
+
+        Like `update_mcp_server`, the id goes in the body (per
+        `UpdateMCPToolsetRequest`), not the path. Only provided fields are sent.
+        """
+        body = self._build_body(
+            {
+                "toolset_id": toolset_id,
+                "toolset_name": toolset_name,
+                "description": description,
+                "tools": tools,
+            }
+        )
+        return await self._request("PUT", "/v1/mcp/toolset", json=body)
+
+    async def delete_mcp_toolset(self, toolset_id: str) -> dict:
+        """Delete an MCP toolset (`DELETE /v1/mcp/toolset/{toolset_id}`)."""
+        return await self._request("DELETE", f"/v1/mcp/toolset/{toolset_id}")

--- a/src/server.py
+++ b/src/server.py
@@ -235,6 +235,18 @@ RESPONSE_FIELDS: dict[str, dict[str, Optional[list[str]]]] = {
         ],
         "full": None,
     },
+    "mcp_toolset": {
+        "minimal": ["toolset_id", "toolset_name"],
+        "standard": [
+            "toolset_id",
+            "toolset_name",
+            "description",
+            "tools",
+            "created_at",
+            "updated_at",
+        ],
+        "full": None,
+    },
 }
 
 VALID_VERBOSITY_LEVELS = {"minimal", "standard", "full"}
@@ -2302,6 +2314,76 @@ async def get_mcp_client_ip() -> dict:
     through an external service.
     """
     return await get_client().get_mcp_client_ip()
+
+
+# ── MCP Toolset operations ──
+
+
+@mcp.tool()
+async def list_mcp_toolsets(verbosity: str = "standard") -> Any:
+    """List defined MCP toolsets (`GET /v1/mcp/toolset`).
+
+    Toolsets are named bundles of tools sourced from one or more registered
+    MCP servers. Once defined, the proxy exposes each toolset as a brokered
+    MCP endpoint at `/toolset/{name}/mcp` (transport-level — not wrapped here).
+
+    Args:
+        verbosity: 'minimal' / 'standard' / 'full'.
+    """
+    payload = await get_client().list_mcp_toolsets()
+    return _filter_response(payload, "mcp_toolset", verbosity)
+
+
+@mcp.tool()
+async def get_mcp_toolset(toolset_id: str, verbosity: str = "standard") -> dict:
+    """Get a single MCP toolset by id (`GET /v1/mcp/toolset/{toolset_id}`).
+
+    Args:
+        toolset_id: upstream toolset id (UUID-shaped).
+        verbosity: 'minimal' / 'standard' / 'full'.
+    """
+    payload = await get_client().get_mcp_toolset(toolset_id)
+    return _filter_response(payload, "mcp_toolset", verbosity)
+
+
+@mcp.tool()
+async def add_mcp_toolset(
+    toolset_name: str,
+    tools: list[str],
+    description: Optional[str] = None,
+) -> dict:
+    """Create an MCP toolset (`POST /v1/mcp/toolset`).
+
+    Args:
+        toolset_name: human-readable name (must satisfy upstream tool-name
+            constraints: A–Z, a–z, 0–9, underscore, dash, dot — no spaces).
+        tools: list of tool identifiers, typically `<server_alias>/<tool_name>`
+            strings sourced from `list_mcp_tools()`.
+        description: optional human-readable description.
+    """
+    return await get_client().add_mcp_toolset(toolset_name, tools, description)
+
+
+@mcp.tool()
+async def update_mcp_toolset(
+    toolset_id: str,
+    toolset_name: Optional[str] = None,
+    description: Optional[str] = None,
+    tools: Optional[list[str]] = None,
+) -> dict:
+    """Update an MCP toolset (`PUT /v1/mcp/toolset`).
+
+    Note: like `update_mcp_server`, the id goes in the body (per
+    `UpdateMCPToolsetRequest`), not the path. Only the fields you pass are
+    sent.
+    """
+    return await get_client().update_mcp_toolset(toolset_id, toolset_name, description, tools)
+
+
+@mcp.tool()
+async def delete_mcp_toolset(toolset_id: str) -> dict:
+    """Delete an MCP toolset (`DELETE /v1/mcp/toolset/{toolset_id}`)."""
+    return await get_client().delete_mcp_toolset(toolset_id)
 
 
 # ── Entrypoint ──

--- a/tests/smoke.py
+++ b/tests/smoke.py
@@ -480,6 +480,17 @@ async def run() -> int:
             results.append(("get_mcp_oauth_user_credential_status", True, "skipped (no servers)"))
         results.append(await _step("get_mcp_client_ip", client.get_mcp_client_ip()))
 
+        # MCP toolsets (read-only — empty on TETRA, create-flow stays in unit tests)
+        toolsets = await client.list_mcp_toolsets()
+        results.append(("list_mcp_toolsets", True, _summarize(toolsets)))
+        first_toolset_id = None
+        if isinstance(toolsets, list) and toolsets and isinstance(toolsets[0], dict):
+            first_toolset_id = toolsets[0].get("toolset_id")
+        if first_toolset_id:
+            results.append(await _step("get_mcp_toolset", client.get_mcp_toolset(first_toolset_id)))
+        else:
+            results.append(("get_mcp_toolset", True, "skipped (no toolsets)"))
+
         # End-to-end: call Context7's resolve-library-id through the gateway.
         # Master keys aren't auto-granted MCP tool access; some proxies return
         # 403 "User not allowed" — that's an upstream auth quirk, not a wrapper

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1549,6 +1549,96 @@ class TestGetMCPClientIp:
         assert result == {"client_ip": "10.0.0.1"}
 
 
+# ── MCP Toolset tools ──
+
+
+class TestListMCPToolsets:
+    @pytest.mark.asyncio
+    async def test_filters_to_toolset_shape(self, mock_client):
+        mock_client.list_mcp_toolsets.return_value = [
+            {
+                "toolset_id": "ts-1",
+                "toolset_name": "research",
+                "description": "...",
+                "tools": ["context7/resolve-library-id"],
+                "drop_me": True,
+            }
+        ]
+        result = await src.server.list_mcp_toolsets("standard")
+        assert "drop_me" not in result[0]
+        assert result[0]["toolset_name"] == "research"
+
+    @pytest.mark.asyncio
+    async def test_minimal(self, mock_client):
+        mock_client.list_mcp_toolsets.return_value = [
+            {"toolset_id": "ts-1", "toolset_name": "research", "tools": []}
+        ]
+        result = await src.server.list_mcp_toolsets("minimal")
+        assert result == [{"toolset_id": "ts-1", "toolset_name": "research"}]
+
+
+class TestGetMCPToolset:
+    @pytest.mark.asyncio
+    async def test_passes_id(self, mock_client):
+        mock_client.get_mcp_toolset.return_value = {
+            "toolset_id": "ts-1",
+            "toolset_name": "research",
+        }
+        result = await src.server.get_mcp_toolset("ts-1", "standard")
+        assert result["toolset_name"] == "research"
+        mock_client.get_mcp_toolset.assert_awaited_once_with("ts-1")
+
+
+class TestAddMCPToolset:
+    @pytest.mark.asyncio
+    async def test_required_fields(self, mock_client):
+        mock_client.add_mcp_toolset.return_value = {"toolset_id": "ts-1"}
+        await src.server.add_mcp_toolset(
+            toolset_name="research",
+            tools=["context7/resolve-library-id"],
+            description="docs lookup",
+        )
+        mock_client.add_mcp_toolset.assert_awaited_once_with(
+            "research", ["context7/resolve-library-id"], "docs lookup"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_description(self, mock_client):
+        mock_client.add_mcp_toolset.return_value = {"toolset_id": "ts-1"}
+        await src.server.add_mcp_toolset(
+            toolset_name="research", tools=["context7/resolve-library-id"]
+        )
+        mock_client.add_mcp_toolset.assert_awaited_once_with(
+            "research", ["context7/resolve-library-id"], None
+        )
+
+
+class TestUpdateMCPToolset:
+    @pytest.mark.asyncio
+    async def test_required_id(self, mock_client):
+        mock_client.update_mcp_toolset.return_value = {"ok": True}
+        await src.server.update_mcp_toolset("ts-1", description="updated")
+        mock_client.update_mcp_toolset.assert_awaited_once_with("ts-1", None, "updated", None)
+
+    @pytest.mark.asyncio
+    async def test_replace_tools(self, mock_client):
+        mock_client.update_mcp_toolset.return_value = {"ok": True}
+        await src.server.update_mcp_toolset(
+            "ts-1", tools=["context7/resolve-library-id", "context7/query-docs"]
+        )
+        mock_client.update_mcp_toolset.assert_awaited_once_with(
+            "ts-1", None, None, ["context7/resolve-library-id", "context7/query-docs"]
+        )
+
+
+class TestDeleteMCPToolset:
+    @pytest.mark.asyncio
+    async def test_passes_id(self, mock_client):
+        mock_client.delete_mcp_toolset.return_value = {"deleted": True}
+        await src.server.delete_mcp_toolset("ts-1")
+        mock_client.delete_mcp_toolset.assert_awaited_once_with("ts-1")
+
+
 class TestClientGuard:
     def test_get_client_unset_raises(self):
         original = src.server._client


### PR DESCRIPTION
## Summary

US [#688](https://taiga.tetra-ai.fr/project/tetra/us/688) — 5-tool follow-up to #558 closing a gap surfaced by the 2026-04-27 coverage audit.

Toolsets are named bundles of tools sourced from one or more registered MCP servers. The 5 admin endpoints CRUD the toolset definitions; the brokered `/toolset/{name}/mcp` transport route is intentionally not wrapped (transport-level, not admin).

| Tool | Endpoint |
|---|---|
| `list_mcp_toolsets` | `GET /v1/mcp/toolset` |
| `get_mcp_toolset` | `GET /v1/mcp/toolset/{toolset_id}` |
| `add_mcp_toolset` | `POST /v1/mcp/toolset` |
| `update_mcp_toolset` | `PUT /v1/mcp/toolset` (toolset_id in body) |
| `delete_mcp_toolset` | `DELETE /v1/mcp/toolset/{toolset_id}` |

Plus 1 new `RESPONSE_FIELDS` shape (`mcp_toolset`).

Server tool count: **108 → 113**.

## Test plan

- [x] Unit tests (`uv run pytest`) — **156 passing** (8 new, 148 pre-existing).
- [x] Live smoke (`uv run python tests/smoke.py`) — **59/59 passing** (added `list_mcp_toolsets` + `get_mcp_toolset` read-only probes; toolsets are empty on TETRA so create-flow stays in unit tests).
- [x] `ruff check` + `ruff format` clean.
- [x] CI green (let actions run).

## Quirks documented in CLAUDE.md

- `PUT /v1/mcp/toolset` carries `toolset_id` in the body (not the path), same convention as `update_mcp_server`.
- Toolset names share the upstream tool-name validator (A–Z, a–z, 0–9, `_`, `-`, `.` only — no spaces); HTTP 400 with `Invalid MCP tool prefix` if violated.

## Release

semrel will cut `v1.5.0` on merge to `master`.