### PR TITLE
chore: public-fit cleanup (drop tracker IDs, env-drive smoke models, generic comments)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,15 +19,15 @@ MCP server for the LiteLLM proxy. Python 3.12, fastmcp (`mcp.server.fastmcp`), h
 - For body schemas with many optional fields (`GenerateKeyRequest`, `UpdateKeyRequest`, `RegenerateKeyRequest`, `NewUserRequest`, `NewCustomerRequest`, `NewOrganizationRequest`, `NewProjectRequest`), expose ~12 common fields as named args and accept the long tail through an `extras: Optional[dict]` argument (merged into the body via `_build_body`/`_build_key_body`).
 - Keep transport agnostic: never call `print` / write to stdout in stdio mode.
 
-## Current scope (US #534 + #535 + #536 + #596 + #558 + #688 + #698)
+## Current scope
 
-- **#534 (v1.0.0):** foundation, `list_models`.
-- **#535 (v1.1.0):** 32 admin tools — Models (5), Model Hub (5), Access Groups (5), Credentials (6), Keys (11). All wrapped with unit tests against `AsyncMock(LiteLLMClient)`.
-- **#536 (v1.2.0):** 31 identity tools — Internal Users (5), Customers (7), Organizations (9, incl. member CRUD), Projects (5), Unified User Access Groups (5).
-- **#596 (v1.3.0):** 19 tools — Budgets (6), Spend (5), Execution (3 — chat/completion/embed, synchronous), Health (5).
-- **#558 (v1.4.0):** 25 MCP-Gateway tools — Server CRUD (6), Submissions (3), Health (1), Tool discovery & invocation (4), Discovery/registry/hub (6), User credentials (4), Utility (1). Lets the proxy broker upstream HTTP-transport MCP servers and list/invoke their tools.
-- **#688 (v1.5.0):** 5 MCP-Toolset tools — `list_mcp_toolsets`, `get_mcp_toolset`, `add_mcp_toolset`, `update_mcp_toolset`, `delete_mcp_toolset`. Toolsets are named bundles of tools sourced from one or more registered MCP servers; the proxy then exposes each toolset as a brokered MCP endpoint at `/toolset/{name}/mcp` (transport-level, not wrapped).
-- **#698:** 1 generic `passthrough(provider, endpoint, method, body, params, headers)` tool — covers ~85 Swagger pass-through ops across 16 provider tags (Anthropic / OpenAI / Vertex AI (+ discovery) / Gemini / Cohere / VLLM / Mistral / Milvus / Bedrock / AssemblyAI (+ EU) / Azure / Azure AI / Cursor / Langfuse). One tool instead of 85 wrappers. `_request()` was extended to accept an optional `headers` kwarg to support provider-specific headers like `anthropic-version`.
+- **Foundation (v1.0.0):** `list_models`.
+- **Admin slice (v1.1.0):** 32 tools — Models (5), Model Hub (5), Access Groups (5), Credentials (6), Keys (11). All wrapped with unit tests against `AsyncMock(LiteLLMClient)`.
+- **Identity slice (v1.2.0):** 31 tools — Internal Users (5), Customers (7), Organizations (9, incl. member CRUD), Projects (5), Unified User Access Groups (5).
+- **Spend / Execution / Health slice (v1.3.0):** 19 tools — Budgets (6), Spend (5), Execution (3 — chat/completion/embed, synchronous), Health (5).
+- **MCP-Gateway slice (v1.4.0):** 25 tools — Server CRUD (6), Submissions (3), Health (1), Tool discovery & invocation (4), Discovery/registry/hub (6), User credentials (4), Utility (1). Lets the proxy broker upstream HTTP-transport MCP servers and list/invoke their tools.
+- **MCP-Toolsets slice (v1.5.0):** 5 tools — `list_mcp_toolsets`, `get_mcp_toolset`, `add_mcp_toolset`, `update_mcp_toolset`, `delete_mcp_toolset`. Toolsets are named bundles of tools sourced from one or more registered MCP servers; the proxy then exposes each toolset as a brokered MCP endpoint at `/toolset/{name}/mcp` (transport-level, not wrapped).
+- **Passthrough slice (v1.6.0):** 1 generic `passthrough(provider, endpoint, method, body, params, headers)` tool — covers ~85 Swagger pass-through ops across 16 provider tags (Anthropic / OpenAI / Vertex AI (+ discovery) / Gemini / Cohere / VLLM / Mistral / Milvus / Bedrock / AssemblyAI (+ EU) / Azure / Azure AI / Cursor / Langfuse). One tool instead of 85 wrappers. `_request()` was extended to accept an optional `headers` kwarg to support provider-specific headers like `anthropic-version`.
 
 ### Upstream quirks
 
@@ -58,6 +58,17 @@ Smoke test (requires a running LiteLLM proxy):
 
 ```bash
 LITELLM_PROXY_URL=http://localhost:4000 LITELLM_API_KEY=sk-... \
-  uv run python -c "import asyncio; from src.litellm_client import LiteLLMClient; \
-    asyncio.run(LiteLLMClient('http://localhost:4000', 'sk-...').list_models())"
+  uv run python tests/smoke.py
 ```
+
+Optional env vars to exercise the execution-path probes (`chat_completion`,
+`completion`, `embed`, `calculate_spend`, `check_health`). Steps that depend
+on a model alias are skipped if the corresponding var is unset — model
+aliases are deployment-specific:
+
+| Variable | Used for |
+|---|---|
+| `SMOKE_CHAT_MODEL` | `chat_completion`, `completion`, `calculate_spend`, fallback for `check_health` |
+| `SMOKE_EMBED_MODEL` | `embed` |
+| `SMOKE_HEALTH_MODEL` | `check_health` (overrides `SMOKE_CHAT_MODEL`) |
+| `SMOKE_SKIP_EXEC=1` | skip all 3 execution probes regardless of model env vars |

--- a/README.md
+++ b/README.md
@@ -4,20 +4,19 @@ MCP server for [LiteLLM](https://github.com/BerriAI/litellm) proxy administratio
 
 **Upstream API reference:** [LiteLLM proxy Swagger](https://litellm-api.up.railway.app/).
 
-Foundation (US #534) shipped `list_models`. Admin slice (US #535) added 32 tools
+The initial release shipped `list_models`. The admin slice added 32 tools
 covering models, model hub, model access groups, credentials, and virtual keys.
-Identity slice (US #536) added 31 tools covering internal users, customers,
+The identity slice added 31 tools covering internal users, customers,
 organizations (with member management), projects, and unified user access
-groups. Spend/execution/health slice (US #596) added 19 tools covering budgets,
+groups. The spend / execution / health slice added 19 tools covering budgets,
 spend reporting, the three core execution verbs (chat / completion / embed),
-and admin health probes. MCP-Gateway slice (US #558) added 25 tools that let
+and admin health probes. The MCP-Gateway slice added 25 tools that let
 the LiteLLM proxy act as an MCP-of-MCPs: register upstream HTTP-transport MCP
-servers and list / invoke their tools through the proxy. MCP-Toolsets slice
-(US #688) added 5 tools to manage named bundles of cross-server tools.
-Passthrough slice (US #698) adds one generic `passthrough` tool that proxies
-to any of LiteLLM's 15+ provider native APIs (~85 Swagger ops in one tool).
-Remaining deferred work in #538 covers governance, multi-modal, and the
-non-passthrough operations of the deferable index.
+servers and list / invoke their tools through the proxy. The MCP-Toolsets slice
+added 5 tools to manage named bundles of cross-server tools. The passthrough
+slice adds one generic `passthrough` tool that proxies to any of LiteLLM's
+15+ provider native APIs (~85 Swagger ops in one tool). Remaining deferred work
+covers governance, multi-modal, and other less-frequently-used operations.
 
 ## Setup
 

--- a/src/litellm_client.py
+++ b/src/litellm_client.py
@@ -1174,8 +1174,8 @@ class LiteLLMClient:
 
     # ── Unified User Access Group operations ──
     #
-    # Wraps `/v1/unified_access_group/*`. Distinct from model-access-groups
-    # (`/access_group/*`, in #535) — unified access groups gate users/teams
+    # Wraps `/v1/unified_access_group/*`. Distinct from the model-access-group
+    # family (`/access_group/*`) — unified access groups gate users/teams
     # against models, MCP servers, and agents in one shape.
 
     async def list_user_access_groups(self) -> Any:
@@ -1668,11 +1668,10 @@ class LiteLLMClient:
         """Admin-register a new upstream MCP server (`POST /v1/mcp/server`).
 
         `transport` is required (`http`, `sse`, `stdio`). For HTTP/SSE provide
-        `url`; for stdio you'd use upstream `command` / `args` / `env` fields
-        via `extras` (TETRA's gateway brokers HTTP-transport upstreams). Pass
-        any of the ~30 NewMCPServerRequest fields not surfaced as named args
-        through `extras` (e.g. `static_headers`, `extra_headers`,
-        `tool_name_to_display_name`, `oauth2_flow`).
+        `url`; for stdio supply upstream `command` / `args` / `env` fields
+        via `extras`. Pass any of the ~30 NewMCPServerRequest fields not
+        surfaced as named args through `extras` (e.g. `static_headers`,
+        `extra_headers`, `tool_name_to_display_name`, `oauth2_flow`).
         """
         body = self._build_mcp_server_body(
             server_id,
@@ -1884,8 +1883,8 @@ class LiteLLMClient:
     async def list_mcp_access_groups(self) -> Any:
         """List MCP access groups (`GET /v1/mcp/access_groups`).
 
-        Distinct from model access groups (`/access_group/list`, in #535) and
-        unified user access groups (`/v1/unified_access_group`, in #536) — these
+        Distinct from model access groups (`/access_group/list`) and
+        unified user access groups (`/v1/unified_access_group`) — these
         gate keys/teams against MCP servers specifically.
         """
         return await self._request("GET", "/v1/mcp/access_groups")

--- a/src/server.py
+++ b/src/server.py
@@ -1463,8 +1463,8 @@ async def delete_project(project_ids: list[str]) -> dict:
 async def list_user_access_groups(verbosity: str = "standard") -> Any:
     """List unified user access groups (`GET /v1/unified_access_group`).
 
-    Distinct from `list_model_access_groups` (in #535) — unified access groups
-    gate users/teams against models, MCP servers, and agents in one shape.
+    Distinct from `list_model_access_groups` — unified access groups gate
+    users/teams against models, MCP servers, and agents in one shape.
 
     Args:
         verbosity: 'minimal' / 'standard' / 'full'.
@@ -2204,9 +2204,8 @@ async def get_mcp_registry() -> Any:
 async def list_mcp_access_groups() -> Any:
     """List MCP access groups (`GET /v1/mcp/access_groups`).
 
-    Distinct from the model-access-groups family (#535) and the unified user
-    access groups (#536) — these gate keys/teams against MCP servers
-    specifically.
+    Distinct from the model-access-groups family and the unified user
+    access groups — these gate keys/teams against MCP servers specifically.
     """
     return await get_client().list_mcp_access_groups()
 

--- a/tests/smoke.py
+++ b/tests/smoke.py
@@ -70,6 +70,13 @@ async def run() -> int:
         print("LITELLM_API_KEY is not set", file=sys.stderr)
         return 1
 
+    # Optional model selectors for the execution-path probes. If unset the
+    # corresponding step is skipped — the proxy's available model_name aliases
+    # are deployment-specific, so the smoke can't assume any of them exist.
+    smoke_chat_model = os.environ.get("SMOKE_CHAT_MODEL")
+    smoke_embed_model = os.environ.get("SMOKE_EMBED_MODEL")
+    smoke_health_model = os.environ.get("SMOKE_HEALTH_MODEL")
+
     client = LiteLLMClient(
         base_url=settings.proxy_url,
         api_key=settings.get_api_key_value(),
@@ -345,74 +352,93 @@ async def run() -> int:
                 ),
             )
         )
-        results.append(
-            await _step(
-                "calculate_spend",
-                client.calculate_spend(
-                    model="tora-no-think",
-                    messages=[{"role": "user", "content": "hi"}],
-                ),
+        # calculate_spend needs a real model_name to look up cost — only run
+        # if the operator told us which alias exists on their proxy.
+        if smoke_chat_model:
+            results.append(
+                await _step(
+                    "calculate_spend",
+                    client.calculate_spend(
+                        model=smoke_chat_model,
+                        messages=[{"role": "user", "content": "hi"}],
+                    ),
+                )
             )
-        )
+        else:
+            results.append(("calculate_spend", True, "skipped (set SMOKE_CHAT_MODEL)"))
 
         # Health family (4 read ops, test_connection skipped — write-shaped)
         results.append(await _step("check_health_backlog", client.check_health_backlog()))
         results.append(await _step("get_health_latest", client.get_health_latest()))
         results.append(await _step("get_health_history", client.get_health_history(limit=5)))
         # /health probes every router-registered deployment — can take 30+s.
-        # Narrow to a single small local model.
-        results.append(await _step("check_health", client.check_health(model="tora-no-think")))
+        # Narrow to a single model when SMOKE_HEALTH_MODEL is provided.
+        target = smoke_health_model or smoke_chat_model
+        if target:
+            results.append(await _step("check_health", client.check_health(model=target)))
+        else:
+            results.append(
+                ("check_health", True, "skipped (set SMOKE_HEALTH_MODEL or SMOKE_CHAT_MODEL)")
+            )
 
         # Execution family (3 paths) — these spend real (small) tokens against
-        # local vLLM deployments. Skip via SMOKE_SKIP_EXEC=1 if needed.
+        # whichever models the operator points us at. Skip via SMOKE_SKIP_EXEC=1
+        # or by leaving SMOKE_CHAT_MODEL / SMOKE_EMBED_MODEL unset.
         if os.environ.get("SMOKE_SKIP_EXEC"):
             results.append(("chat_completion", True, "skipped (SMOKE_SKIP_EXEC)"))
             results.append(("completion", True, "skipped (SMOKE_SKIP_EXEC)"))
             results.append(("embed", True, "skipped (SMOKE_SKIP_EXEC)"))
         else:
-            try:
-                cc = await client.chat_completion(
-                    model="tora-no-think",
-                    messages=[{"role": "user", "content": "Reply with: ok"}],
-                    body={"max_tokens": 5, "temperature": 0.0},
-                )
-                results.append(("chat_completion", True, _summarize(cc)))
-            except LiteLLMAPIError as e:
-                results.append(("chat_completion", False, f"APIError {e.status_code}: {e}"))
-
-            # Legacy /v1/completions: many chat-only models 400 here. Mark
-            # 400/404/422 as "expected" since no legacy-text deployment exists.
-            try:
-                comp = await client.completion(
-                    model="tora-no-think",
-                    prompt="The capital of France is",
-                    body={"max_tokens": 3, "temperature": 0.0},
-                )
-                results.append(("completion", True, _summarize(comp)))
-            except LiteLLMAPIError as e:
-                if e.status_code in {400, 404, 422}:
-                    results.append(
-                        ("completion", True, f"{e.status_code} (no legacy-text deployment)")
+            if smoke_chat_model:
+                try:
+                    cc = await client.chat_completion(
+                        model=smoke_chat_model,
+                        messages=[{"role": "user", "content": "Reply with: ok"}],
+                        body={"max_tokens": 5, "temperature": 0.0},
                     )
-                else:
-                    results.append(("completion", False, f"APIError {e.status_code}: {e}"))
+                    results.append(("chat_completion", True, _summarize(cc)))
+                except LiteLLMAPIError as e:
+                    results.append(("chat_completion", False, f"APIError {e.status_code}: {e}"))
 
-            try:
-                emb = await client.embed(
-                    model="qwen/qwen3-embedding-0.6b",
-                    input=["smoke test"],
-                )
-                results.append(("embed", True, _summarize(emb)))
-            except LiteLLMAPIError as e:
-                results.append(("embed", False, f"APIError {e.status_code}: {e}"))
+                # Legacy /v1/completions: many chat-only models 400 here. Mark
+                # 400/404/422 as expected when no legacy-text deployment exists.
+                try:
+                    comp = await client.completion(
+                        model=smoke_chat_model,
+                        prompt="The capital of France is",
+                        body={"max_tokens": 3, "temperature": 0.0},
+                    )
+                    results.append(("completion", True, _summarize(comp)))
+                except LiteLLMAPIError as e:
+                    if e.status_code in {400, 404, 422}:
+                        results.append(
+                            ("completion", True, f"{e.status_code} (no legacy-text deployment)")
+                        )
+                    else:
+                        results.append(("completion", False, f"APIError {e.status_code}: {e}"))
+            else:
+                results.append(("chat_completion", True, "skipped (set SMOKE_CHAT_MODEL)"))
+                results.append(("completion", True, "skipped (set SMOKE_CHAT_MODEL)"))
+
+            if smoke_embed_model:
+                try:
+                    emb = await client.embed(
+                        model=smoke_embed_model,
+                        input=["smoke test"],
+                    )
+                    results.append(("embed", True, _summarize(emb)))
+                except LiteLLMAPIError as e:
+                    results.append(("embed", False, f"APIError {e.status_code}: {e}"))
+            else:
+                results.append(("embed", True, "skipped (set SMOKE_EMBED_MODEL)"))
 
         # MCP Gateway family — read-only paths + Context7 end-to-end.
         servers = await client.list_mcp_servers()
         results.append(("list_mcp_servers", True, _summarize(servers)))
 
         # Locate Context7 (or any registered HTTP-transport server) for the
-        # end-to-end probe. We don't auto-register because TETRA's proxy
-        # already has Context7 registered; double-registration would 409.
+        # end-to-end probe. We don't auto-register — if the proxy already has
+        # Context7 registered, double-registration would 409.
         first_server_id = None
         first_server_alias = None
         if isinstance(servers, list):
@@ -513,7 +539,8 @@ async def run() -> int:
             else:
                 results.append(("passthrough[anthropic]", False, f"APIError {e.status_code}: {e}"))
 
-        # MCP toolsets (read-only — empty on TETRA, create-flow stays in unit tests)
+        # MCP toolsets (read-only — toolsets may be empty on the proxy under
+        # test; create-flow stays in unit tests).
         toolsets = await client.list_mcp_toolsets()
         results.append(("list_mcp_toolsets", True, _summarize(toolsets)))
         first_toolset_id = None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -157,7 +157,7 @@ class TestListPublicModels:
 class TestGetPublicHubInfo:
     @pytest.mark.asyncio
     async def test_passthrough(self, mock_client):
-        payload = {"title": "Tetra Models", "description": "...", "useful_links": {}}
+        payload = {"title": "Test Hub", "description": "...", "useful_links": {}}
         mock_client.get_public_hub_info.return_value = payload
         result = await src.server.get_public_hub_info()
         assert result == payload


### PR DESCRIPTION
## Summary

Audit pass to make the repo read as a generic public MCP server rather than a mirror of an internal tracker. No functional changes to the wrapped tools — the **API surface is identical** before/after.

### Three categories cleaned

1. **Internal-tracker references stripped.** Drop `US #N` Taiga IDs from CLAUDE.md, README.md, and src/ docstrings. Keep semantic slice names (Foundation / Admin / Identity / Spend-Exec-Health / MCP-Gateway / Toolsets / Passthrough) — those convey what shipped without leaking ticket IDs that don't mean anything to a public reader.
2. **Smoke model selectors made env-driven.** Previously hardcoded model aliases that only existed on one specific deployment, breaking the smoke for anyone else cloning the repo. Now uses `SMOKE_CHAT_MODEL`, `SMOKE_EMBED_MODEL`, `SMOKE_HEALTH_MODEL` env vars; steps that depend on a model alias skip cleanly when unset.
3. **Internal-deployment comments made generic.** "TETRA's proxy" / "empty on TETRA" → "the proxy" / "may be empty on the proxy under test". Test fixture "Tetra Models" → "Test Hub".

## Test plan

- [x] Unit tests (`uv run pytest`) — **160 passing** (no test changes other than the fixture string).
- [x] Live smoke with the prior model aliases provided via env: `SMOKE_CHAT_MODEL=tora-no-think SMOKE_EMBED_MODEL=qwen/qwen3-embedding-0.6b uv run python tests/smoke.py` → **60/60 passing**, identical to the prior hardcoded version.
- [x] `ruff check` + `ruff format` clean.

## Release impact

`chore:` commit type — **semrel will not bump a version**. v1.6.0 stays current. This is appropriate; the public API is unchanged.

## What's still TETRA-attributed (intentional)

- `LICENSE` — `Copyright (c) 2026 TETRA`. Org-level attribution, must stay.
- `pyproject.toml` — `authors = [{ name = "TETRA" }]`. Same.
- `README.md` clone URL — `github.com/TETRA-2023/litellm-mcp.git`. Required for cloning.