### PR TITLE
ci: add gitleaks job and decouple :stable from default-branch builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,24 @@ on:
     branches: [master, main]
 
 jobs:
+  secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        run: |
+          set -euo pipefail
+          VERSION=8.30.1
+          curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+
+      - name: Scan repo (full history)
+        run: gitleaks detect --no-banner --redact --verbose
+
   test:
     runs-on: ubuntu-latest
     steps:
@@ -49,7 +67,7 @@ jobs:
         run: uv run ruff format --check src/ tests/
 
   docker:
-    needs: [test, lint]
+    needs: [secrets, test, lint]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -82,28 +100,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract version from pyproject.toml
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        id: version
-        run: |
-          VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
-          echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+' || { echo "::error::Invalid version: $VERSION"; exit 1; }
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
-      - name: Build and push image
+      - name: Build and push image (:latest)
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: docker/build-push-action@v7
         with:
           context: .
           push: true
-          tags: |
-            ${{ steps.repo.outputs.image }}:latest
-            ${{ steps.repo.outputs.image }}:${{ steps.version.outputs.version }}
+          tags: ${{ steps.repo.outputs.image }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
   release:
-    needs: [test, lint]
+    needs: [secrets, test, lint]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     concurrency: release

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,0 +1,43 @@
+name: Release Image
+
+on:
+  push:
+    tags: ["v*.*.*"]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Normalize image name
+        id: repo
+        run: echo "image=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image (:stable + :version)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ steps.repo.outputs.image }}:stable
+            ${{ steps.repo.outputs.image }}:${{ steps.version.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
Mirrors the langfuse-mcp CI structure with one fix: makes `:stable` actually mean stable. Companion to identical PRs in pytaiga-mcp, homarr-mcp, langfuse-mcp.

- **Adds `secrets:` job** running gitleaks v8.30.1 against full history; wired into `needs:` of both `docker` and `release`. Verified clean against the full master history locally.
- **Splits docker publishing** into two phases:
  - `ci.yml` `docker` job now publishes **only `:latest`** on master pushes. Removes the old `:<pyproject-version>` line.
  - New **`release-image.yml`** workflow triggers on `v*.*.*` tag pushes and publishes `:stable` + `:<version>` from the tagged commit.

## Tag semantics after merge
| Tag | Updated by |
|---|---|
| `:latest` | every master push |
| `:stable` | only when semantic-release cuts a new tag |
| `:X.Y.Z` | published once, then immutable |

## Test plan
- [x] `gitleaks detect` clean against full master history
- [ ] CI green on this PR
- [ ] After merge: tag push triggers release-image.yml