### PR TITLE
ci: switch default branch references from master to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master, main]
+    branches: [main]
   pull_request:
-    branches: [master, main]
+    branches: [main]
 
 jobs:
   secrets:
@@ -93,7 +93,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Log in to GHCR
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -101,7 +101,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push image (:latest)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -113,7 +113,7 @@ jobs:
   release:
     needs: [secrets, test, lint]
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     concurrency: release
     permissions:
       id-token: write

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ asyncio_mode = "auto"
 
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]
-branch = "master"
+branch = "main"
 commit_message = "chore(release): v{version}"
 build_command = ""
 


### PR DESCRIPTION
## Summary
The repo's default branch was renamed `master -> main` via the GitHub API. This PR updates the in-repo references to match.

- `ci.yml` `on:` filter: `branches: [master, main]` -> `branches: [main]`
- `ci.yml` job guards: 3x `github.ref == 'refs/heads/master'` -> `'refs/heads/main'`
- `pyproject.toml` `[tool.semantic_release].branch`: `"master"` -> `"main"`

## Test plan
- [x] No `master` references remain in `.github/`, `pyproject.toml`, `CLAUDE.md`
- [ ] CI green on this PR
- [ ] After merge: a main push triggers ci.yml correctly; tag push triggers release-image.yml

## Companion PR
- homarr-mcp #8: identical change being applied in parallel.