### PR TITLE
chore: add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+# Dependabot configuration.
+#
+# - uv: security + version-update PRs for Python deps in uv.lock / pyproject.toml.
+# - github-actions: keeps the action pins in .github/workflows current.
+#
+# These are first-party TETRA repos, so PRs are mergeable as-is after CI.
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Europe/Paris"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Europe/Paris"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
Adds `.github/dependabot.yml` so this repo gets routine **version-update** PRs (weekly, Mon 08:00 Europe/Paris), not just security alerts. Watches the dependency ecosystem + `github-actions`. Brings it in line with open-webui-mcp, the only MCP that already had a config.