### PR TITLE
fix(ci): pin release-job checkout to v6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,9 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+    ignore:
+      # actions/checkout@v7 breaks the release job's authenticated checkout:
+      # the custom GH_TOKEN is not injected -> "could not read Username".
+      # Release job pinned to v6; hold the major bump until the v7 token flow works.
+      - dependency-name: "actions/checkout"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Reverts **only the `release` job** checkout to `actions/checkout@v6`.

`@v7` does not inject the custom `GH_TOKEN`, so the authenticated `fetch-depth: 0` checkout fails with `could not read Username` (exit 128). `lint`/`test`/`docker`/`secrets` keep `@v7` (default `GITHUB_TOKEN` works).

Also adds a Dependabot `ignore` for the `actions/checkout` major bump so it isn't immediately re-opened. Fixes the red `release` job introduced by the checkout 6→7 Dependabot merge.