### PR TITLE
chore(ci): restore release-job checkout to v7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,9 +28,3 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
-    ignore:
-      # actions/checkout@v7 breaks the release job's authenticated checkout:
-      # the custom GH_TOKEN is not injected -> "could not read Username".
-      # Release job pinned to v6; hold the major bump until the v7 token flow works.
-      - dependency-name: "actions/checkout"
-        update-types: ["version-update:semver-major"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Cleanup of the earlier mistaken fix. The release-job failure was an **expired `GH_TOKEN`** (now rotated), not `actions/checkout@v7`.

- Restores the release-job checkout `@v6` → `@v7` (matches lint/test/docker).
- Removes the `actions/checkout` Dependabot `ignore` that is no longer needed.